### PR TITLE
Show glossary term properly

### DIFF
--- a/src/components/Explorer.js
+++ b/src/components/Explorer.js
@@ -46,7 +46,14 @@ const Explorer = ({ params, dispatch }) => {
           <div className='clearfix mb3 mxn1'>
             <div className='sm-col sm-col-8 px1'>
               <p className='bold'>
-                Incidents of <Term>{crime}</Term> are on the
+                Incidents of
+                <Term
+                  dispatch={dispatch}
+                  id='murder and nonnegligent homicide'
+                >
+                  {crime}
+                </Term>
+                are on the
                 rise in {state}, but lower than 5 or 10 years ago.
               </p>
               <p>

--- a/src/components/Glossary.js
+++ b/src/components/Glossary.js
@@ -9,16 +9,18 @@ import terms from '../../data/terms.json'
 class Glossary extends React.Component {
   constructor() {
     super()
+    this.applyProps = ::this.applyProps
+    this.showTerm = ::this.showTerm
     this.toggleGlossary = ::this.toggleGlossary
   }
 
   componentDidMount() {
     this.glossaryEl = new GlossaryPanel(terms) // eslint-disable-line no-new
-    if (this.props.isVisible) this.glossaryEl.show()
+    this.applyProps(this.props)
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setVisibility(nextProps.isVisible)
+    this.applyProps(nextProps)
   }
 
   shouldComponentUpdate() { return false }
@@ -26,6 +28,16 @@ class Glossary extends React.Component {
   setVisibility(isVisible) {
     if (isVisible) this.glossaryEl.show()
     else this.glossaryEl.hide()
+  }
+
+  showTerm(term) {
+    if (term) this.glossaryEl.findTerm(term)
+  }
+
+  applyProps(props) {
+    const { isVisible, term } = props
+    this.setVisibility(isVisible)
+    if (term) this.showTerm(term)
   }
 
   toggleGlossary() {
@@ -75,14 +87,11 @@ class Glossary extends React.Component {
 }
 
 Glossary.defaultProps = {
-  dispatch: a => {
-    console.error('dispatch() was not provided to <Glossary /> as a prop', a)
-  },
   isVisible: false,
 }
 
 Glossary.propTypes = {
-  dispatch: React.PropTypes.func,
+  dispatch: React.PropTypes.func.isRequired,
   isVisible: React.PropTypes.bool,
 }
 

--- a/src/components/Term.js
+++ b/src/components/Term.js
@@ -2,22 +2,28 @@
 
 import React from 'react'
 
-const showTerm = term => {
-  const id = term.target.getAttribute('data-term')
-  console.log(`fire off action to show ${id} in the glossary`)
-  window.Glossary.show()
-  window.Glossary.findTerm(id)
+import { showTerm } from '../actions/glossaryActions'
+
+const Term = ({ children, dispatch, id }) => {
+  const handler = e => {
+    e.preventDefault()
+    dispatch(showTerm(id))
+  }
+
+  return (
+    <button
+      className='btn mx1 p0 bg-navy white align-baseline'
+      onClick={handler}
+      role='button'
+    >
+      {children}
+    </button>
+  )
 }
 
-const Term = ({ children, id }) => (
-  <button
-    className='btn p0 bg-navy white align-baseline'
-    data-term={id || children}
-    onClick={showTerm}
-    role='button'
-  >
-    {children}
-  </button>
-)
+Term.propTypes = {
+  dispatch: React.PropTypes.func.isRequired,
+  id: React.PropTypes.string.isRequired,
+}
 
 export default Term

--- a/src/reducers/glossaryReducer.js
+++ b/src/reducers/glossaryReducer.js
@@ -1,22 +1,32 @@
 import {
   GLOSSARY_HIDE,
   GLOSSARY_SHOW,
+  GLOSSARY_SHOW_TERM,
 } from '../actions/actionTypes'
 
 const initialState = {
   isVisible: false,
+  term: null,
 }
 
 export default (state = initialState, action) => {
   switch (action.type) {
     case GLOSSARY_HIDE:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         isVisible: false,
-      })
+      }
     case GLOSSARY_SHOW:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         isVisible: true,
-      })
+      }
+    case GLOSSARY_SHOW_TERM:
+      return {
+        ...state,
+        isVisible: true,
+        term: action.term,
+      }
     default:
       return state
   }

--- a/test/reducers/glossaryReducer.test.js
+++ b/test/reducers/glossaryReducer.test.js
@@ -3,16 +3,16 @@
 import {
   GLOSSARY_HIDE,
   GLOSSARY_SHOW,
+  GLOSSARY_SHOW_TERM,
 } from '../../src/actions/actionTypes';
 
 import reducer from '../../src/reducers/glossaryReducer';
 
 describe('glossaryReducer', () => {
-  describe('initial state', () => {
-    it('should return isVisible: false', () => {
-      const initialState = reducer(undefined, { type: 'fake' })
-      expect(initialState.isVisible).toEqual(false)
-    })
+  it('it should return the initial state', () => {
+    const initialState = reducer(undefined, { type: 'fake' })
+    expect(initialState.isVisible).toEqual(false)
+    expect(initialState.term).toEqual(null)
   })
 
   describe('GLOSSARY_HIDE action type', () => {
@@ -28,6 +28,22 @@ describe('glossaryReducer', () => {
       const initialState = { isVisible: false }
       const actual = reducer(initialState, { type: GLOSSARY_SHOW })
       expect(actual.isVisible).toEqual(true)
+    })
+  })
+
+  describe('GLOSSARY_SHOW_TERM action type', () => {
+    it('should set isVisible to true', () => {
+      const initialState = { isVisible: false }
+      const action = { term: 'fake', type: GLOSSARY_SHOW_TERM }
+      const actual = reducer(initialState, action)
+      expect(actual.isVisible).toEqual(true)
+    })
+
+    it('should set term to action.term', () => {
+      const initialState = { isVisible: false }
+      const action = { term: 'fake', type: GLOSSARY_SHOW_TERM }
+      const actual = reducer(initialState, action)
+      expect(actual.term).toEqual(action.term)
     })
   })
 })


### PR DESCRIPTION
* Add state reducer for the SHOW_TERM action type
* `<Glossary />` uses the newly reduced state to show a term

I think this refs #78