### PR TITLE
responsive timechart, better tooltip

### DIFF
--- a/sass/components/_charts.scss
+++ b/sass/components/_charts.scss
@@ -1,5 +1,10 @@
 .axis {
   fill: none;
-  font-family: $font-sans-serif;
-  font-size: 10px;
+  font-family: $font-monospace;
+  font-size: $h6;
+
+  line,
+  path {
+    stroke: #979797;
+  }
 }

--- a/src/components/Explorer.js
+++ b/src/components/Explorer.js
@@ -71,8 +71,14 @@ const Explorer = ({ params, dispatch }) => {
               <img className='px1' width='24' src='/img/download.svg' alt='download' />
               <img className='px1' width='24' src='/img/share.svg' alt='share' />
             </div>
-            <h3 className='mt0 mb3'>Reported {crime}s in {state}, 2005 - 2014</h3>
-            <TimeChart data={timeData2} keys={['foo', 'bar']} />
+            <h2 className='mt0 mb2'>Reported {crime}s, 2005—2014</h2>
+            <p className='mb2 md-col-10 lg-col-8'>
+              Ohio’s incident rate surpasses that of the United States, and in
+              2014 was 35.3 incidents per 100,000 people (legacy definition).
+            </p>
+            <div className='mb2'>
+              <TimeChart data={timeData2} keys={['foo', 'bar']} />
+            </div>
           </div>
           <div>
             <h2 className='pb1 serif border-bottom border-silver'>Details</h2>

--- a/src/components/YAxis.js
+++ b/src/components/YAxis.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 const YAxis = ({
-  tickCt = 8,
+  tickCt = 4,
   tickSizeOuter = 6,
   scale,
 }) => {
@@ -23,7 +23,7 @@ const YAxis = ({
 
   return (
     <g className='axis' textAnchor='end'>
-      <path className='domain' stroke='#000' d={domain} />
+      <path className='domain display-none' d={domain} />
       {ticks}
     </g>
   )


### PR DESCRIPTION
this PR does a couple things:

1) makes timechart responsive
2) adds a better tooltip: it finds the closest x coordinate that has a data point and then adds a vertical line and a text box with the data values for all points along that vertical y line intersection

i.e.,
![image](https://cloud.githubusercontent.com/assets/1060893/21668248/fda36778-d2cd-11e6-8e3b-41875ef583e7.png)
