### PR TITLE
Store all API responses in localStorage to increase speed

### DIFF
--- a/src/util/localStorage.js
+++ b/src/util/localStorage.js
@@ -1,0 +1,16 @@
+
+const getItem = key => {
+  if (!window.localStorage) return Promise.resolve(null)
+
+  const item = window.localStorage.getItem(key)
+  return Promise.resolve((item !== null) ? JSON.parse(item) : null)
+}
+
+const setItem = (key, value) => {
+  if (!window.localStorage) return Promise.resolve(null)
+
+  window.localStorage.setItem(key, JSON.stringify(value))
+  return Promise.resolve(true)
+}
+
+export default { getItem, setItem }

--- a/test/util/localStorage.test.js
+++ b/test/util/localStorage.test.js
@@ -1,0 +1,74 @@
+/* eslint no-undef: 0 */
+
+import storage from '../../src/util/localStorage'
+
+const createStorageMock = () => {
+  const store = {}
+
+  return {
+    getItem: key => (key in store ? store[key] : null),
+    setItem: (key, value) => (store[key] = value || ''),
+  }
+}
+
+describe('localStorage utility', () => {
+  describe('without localStorage', () => {
+    beforeEach(() => {
+      window.localStorage = undefined
+    })
+
+    it('getItem() should return null', done => {
+      storage.getItem('fake-item').then(item => {
+        expect(item).toEqual(null)
+        done()
+      })
+    })
+
+    it('setItem() should return null', () => {
+      storage.setItem('fake-item', { fakeKey: 'fake-value' }).then(item => {
+        expect(item).toEqual(null)
+        done()
+      })
+    })
+  })
+
+  describe('with localStorage', () => {
+    beforeEach(() => {
+      window.localStorage = createStorageMock()
+    })
+
+    describe('getItem()', () => {
+      it('should return null if the key does not exist', done => {
+        const key = 'fake-item'
+
+        storage.getItem(key).then(item => {
+          expect(item).toEqual(null)
+          done()
+        })
+      })
+
+      it('should return the value if it exists', done => {
+        const key = 'fake-item'
+        const data = { fakeKey: 'fakeValue' }
+
+        window.localStorage.setItem(key, JSON.stringify(data))
+        storage.getItem(key).then(item => {
+          expect(item).toEqual(data)
+          done()
+        })
+      })
+    })
+
+    describe('setItem()', () => {
+      it('should return true if set was successful', done => {
+        const key = 'fake-item'
+        const data = { fakeKey: 'fakeValue' }
+
+        storage.setItem(key, data).then(item => {
+          expect(item).toEqual(true)
+          done()
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Since the data can be heavily cached, we can use localStorage to cache all the responses to improve the functioning of the application. We use the API URL as a cache key (with all query params sorted alphabetically for consistency), and store the serialized JSON response from the API.

If localStorage is not available, the app will just make the request everytime it is needed.

Closes #96