### PR TITLE
Make footer stylings responsive

### DIFF
--- a/sass/util/_border.scss
+++ b/sass/util/_border.scss
@@ -1,3 +1,7 @@
 .border-blue { border-color: $blue; }
 .border-bottom-dotted { border-bottom: $border-width dotted $black; }
 .border-w2 { border-width: 2px; }
+
+@media #{$breakpoint-md} {
+  .md-border-none { border: 0; }
+}

--- a/sass/util/_display.scss
+++ b/sass/util/_display.scss
@@ -1,0 +1,17 @@
+@media #{$breakpoint-sm} {
+  .sm-block { display: block; }
+  .sm-inline { display: inline; }
+  .sm-inline-block { display: inline-block; }
+}
+
+@media #{$breakpoint-md} {
+  .md-block { display: block; }
+  .md-inline { display: inline; }
+  .md-inline-block { display: inline-block; }
+}
+
+@media #{$breakpoint-lg} {
+  .lg-block { display: block; }
+  .lg-inline { display: inline; }
+  .lg-inline-block { display: inline-block; }
+}

--- a/sass/util/_space-addon.scss
+++ b/sass/util/_space-addon.scss
@@ -135,3 +135,9 @@
   .sm-px8 { padding-left: $space-8; padding-right: $space-8; }
   .sm-py8 { padding-bottom: $space-8; padding-top: $space-8; }
 }
+
+@media #{$breakpoint-md} {
+  .md-ml0 { margin-left: 0; }
+
+  .md-pl0 { padding-left: 0; }
+}

--- a/sass/util/all.scss
+++ b/sass/util/all.scss
@@ -3,6 +3,7 @@
 @import 'border';
 @import 'colors';
 @import 'cursor';
+@import 'display';
 @import 'line-height';
 @import 'space-addon';
 @import 'space-misc';

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,9 +1,44 @@
 import React from 'react'
 import { Link } from 'react-router'
 
-const linkClass = 'mr1 pr1 white border-right border-white'
-const linkClassLast = 'white'
-
+const firstRow = [
+  {
+    text: 'Home',
+    href: '/',
+  },
+  {
+    text: 'Explorer',
+    href: '/explorer',
+  },
+  {
+    text: 'Downloads and Documentation',
+    href: '/downloads-and-docs',
+  },
+  {
+    text: 'About',
+    href: '/about',
+  },
+]
+const secondRow = [
+  {
+    text: 'Glossary',
+    href: '/#!',
+  },
+  {
+    text: 'Privacy Policy',
+    href: '/#!',
+  },
+  {
+    text: 'License',
+    href: '/#!',
+  },
+  {
+    text: 'Feedback',
+    href: '/#!',
+  },
+]
+const liCls = 'mb1 ml1 fs-10 md-fs-12 sm-block md-inline-block'
+const linkCls = 'border-left border-white white pl1'
 const scrollToTop = () => window.scrollTo(0, 0)
 
 const Footer = () => (
@@ -27,52 +62,43 @@ const Footer = () => (
           </div>
         </div>
         <div className='sm-col sm-col-6 sm-col-right fs-14'>
-          <div className='pb3 caps'>
-            <ul className='list-style-none px0 m0 mb1'>
-              <li className='inline-block'>
-                <Link
-                  className={linkClass}
-                  onClick={scrollToTop}
-                  to='/'
-                >
-                  Explorer
-                </Link>
-              </li>
-              <li className='inline-block'>
-                <Link
-                  className={linkClass}
-                  onClick={scrollToTop}
-                  to='/downloads-and-docs'
-                >
-                  Downloads & Documentation
-                </Link>
-              </li>
-              <li className='inline-block'>
-                <Link
-                  className={linkClass}
-                  onClick={scrollToTop}
-                  to='/about'
-                >
-                  About
-                </Link>
-              </li>
-              <li className='inline-block'>
-                <Link className={linkClassLast} to='/'>Glossary</Link>
-              </li>
+          <div className='pb3 caps clearfix'>
+            <ul className='list-style-none px0 m0 mb1 col col-6 md-col-12'>
+              {firstRow.map((l, i) => {
+                const isFirst = i === 0
+                return (
+                  <li
+                    key={i}
+                    className={`${liCls} ${isFirst && 'md-ml0'}`}
+                  >
+                    <Link
+                      className={`${linkCls} ${isFirst && 'md-pl0 md-border-none'}`}
+                      onClick={scrollToTop}
+                      to={l.href}
+                    >
+                      {l.text}
+                    </Link>
+                  </li>
+                )
+              })}
             </ul>
-            <ul className='list-style-none px0 my0'>
-              <li className='inline-block'>
-                <Link className={linkClass} to='/'>Accessibility</Link>
-              </li>
-              <li className='inline-block'>
-                <Link className={linkClass} to='/'>Privacy Policy</Link>
-              </li>
-              <li className='inline-block'>
-                <Link className={linkClass} to='/'>License</Link>
-              </li>
-              <li className='inline-block'>
-                <Link className={linkClassLast} to='/'>Feedback</Link>
-              </li>
+            <ul className='list-style-none px0 my0 col col-6 md-col-12'>
+              {secondRow.map((l, i) => {
+                const isFirst = i === 0
+                return (
+                  <li
+                    key={i}
+                    className={`${liCls} ${isFirst && 'md-ml0'}`}
+                  >
+                    <Link
+                      className={`${linkCls} ${isFirst && 'md-pl0 md-border-none'}`}
+                      to={l.href}
+                    >
+                      {l.text}
+                    </Link>
+                  </li>
+                )
+              })}
             </ul>
           </div>
           <div>


### PR DESCRIPTION
Alter the way `<Footer />` renders to DRY out the code and to have responsive styling.

![mobile-footer](https://cloud.githubusercontent.com/assets/780941/22768302/23b0d17a-ee4f-11e6-8b1a-dc20339c0f30.gif)

Should close [crime-data-api#325](/18F/crime-data-api/issues/325)