### PR TITLE
collapse nibrs entries into "other"

### DIFF
--- a/src/components/NibrsTable.js
+++ b/src/components/NibrsTable.js
@@ -120,7 +120,7 @@ class NibrsTable extends React.Component {
 }
 
 NibrsTable.defaultProps = {
-  rowLim: 10,
+  rowLim: 12,
 }
 
 export default NibrsTable

--- a/test/components/NibrsTable.test.js
+++ b/test/components/NibrsTable.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import NibrsTable from '../../src/components/NibrsTable';
+
+describe('NibrsTable', () => {
+  const data = n => [...Array(n)].map((_, i) => ({ key: i, count: 10 }))
+
+  it('NibrsTable has row for each data entry', () => {
+    const entries = 3
+    const table = shallow(<NibrsTable data={data(entries)} />)
+
+    expect(table.find('tbody tr').length).toEqual(entries)
+  })
+
+  it('NibrsTable collapses entries above rowLim into 1 row', () => {
+    const [entries, rowLim] = [15, 5]
+    const table = shallow(<NibrsTable data={data(entries)} rowLim={rowLim} />)
+    const otherCell = table.find('tbody tr td').last()
+
+    expect(table.find('tbody tr').length).toEqual(rowLim + 1)
+    expect(otherCell.text()).toEqual(`Other (${entries - rowLim})`)
+  })
+})


### PR DESCRIPTION
all entries after "rowLim" are collapsed into an "Other" bucket; tests included!

preview:
![image](https://cloud.githubusercontent.com/assets/1060893/22846868/c5822530-efb7-11e6-9e94-8e11158b32cd.png)
