### PR TITLE
Add source to trend chart

### DIFF
--- a/src/components/TrendContainer.js
+++ b/src/components/TrendContainer.js
@@ -6,13 +6,18 @@ import startCase from 'lodash.startcase'
 import DownloadDataBtn from './DownloadDataBtn'
 import Loading from './Loading'
 import NoData from './NoData'
+import Term from './Term'
 import TrendChart from './TrendChart'
 
 const TrendContainer = ({
   crime, place, filters, data, dispatch, loading, keys,
 }) => {
   const { timeFrom, timeTo } = filters
-
+  const srs = (
+    <Term id='summary reporting system (srs)' dispatch={dispatch}>
+      Summary (SRS)
+    </Term>
+  )
   let content = null
   if (loading) content = <Loading />
   else if (!data || data.length === 0) content = <NoData />
@@ -45,9 +50,11 @@ const TrendContainer = ({
         </div>
       </div>
       <div className='mb2'>{content}</div>
+      {!loading && (
       <div className='center italic fs-12 mb8'>
-        <p>Source: {startCase(place)} reported Summary (SRS) data from {timeFrom}–{timeTo}.</p>
+        <p>Source: {startCase(place)} reported {srs} data from {timeFrom}–{timeTo}.</p>
       </div>
+      )}
     </div>
   )
 }

--- a/src/components/TrendContainer.js
+++ b/src/components/TrendContainer.js
@@ -44,7 +44,10 @@ const TrendContainer = ({
           </div>
         </div>
       </div>
-      <div className='mb8'>{content}</div>
+      <div className='mb2'>{content}</div>
+      <div className='center italic fs-12 mb8'>
+        <p>Source: {startCase(place)} reported Summary (SRS) data from {timeFrom}–{timeTo}.</p>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Current implementation:

![](https://d3vv6lp55qjaqc.cloudfront.net/items/1E0w2i0V2y3v2z423P31/Screen%20Shot%202017-02-13%20at%2010.44.28%20PM.png?X-CloudApp-Visitor-Id=586613&v=0b959f56)

@AvivaOskow and @amberwreed In the design, "Summary (SRS)" is underlined as if it is a link. What should that do? I was thinking it might be a term but it didn't have the glossary icon next to it.

@nicoleslaw Ping for your approval too

To close #254 
