### PR TITLE
Use old endpoint for location name NIBRS dimension

### DIFF
--- a/server.js
+++ b/server.js
@@ -27,7 +27,7 @@ app.get('/api/*', (req, res) => {
   return http.get(route, { params }).then(r => {
     res.send(r.data)
   }).catch(e => {
-    res.send({ status: e.response.status, results: [] })
+    res.status(e.response.status).end()
   })
 })
 

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -77,7 +77,8 @@ const getNibrs = ({ crime, dim, place, type }) => {
   const field = dimensionEndpoints[dim]
   const loc = (place === nationalKey) ? 'national' : `states/${stateCodes[place]}`
 
-  const url = `${API}/${type}s/count/${loc}/${field}/offenses`
+  const base = `${API}/${type}s/count/${loc}/${field}`
+  const url = (dim !== 'locationName') ? `${base}/offenses` : base
   const params = { per_page: 50, aggregate_many: false, explorer_offense: crime }
 
   return get(url, params).then(d => ({


### PR DESCRIPTION
@brendansudol What do you think about this approach to the problem you outlined in #269?

Things I like:
* Keeping the server as simple as possible is nice so that we only have one place to look for application logic
* Still returns data from the endpoint for display by the UI

Things I dislike:
* The information shown is incorrect in this UI, as the location values shown are for the place and time and not the offense. This can be fixed once the API endpoint is in place.