### PR TITLE
design tweaks

### DIFF
--- a/src/components/DownloadBulkNibrs.js
+++ b/src/components/DownloadBulkNibrs.js
@@ -100,7 +100,7 @@ class DownloadBulkNibrs extends React.Component {
                 ))}
               </select>
             </div>
-            <div className='sm-col sm-col-3 md-col-2 px1 mb2 sm-m0'>
+            <div className='sm-col sm-col-3 lg-col-2 px1 mb2 sm-m0'>
               <button
                 className='col-12 btn btn-primary'
                 disabled={isBtnDisabled}

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -139,9 +139,9 @@ const Home = ({ appState, dispatch, location }) => {
             </button>
           </div>
           <h2 className='mt0 mb3 fs-22 sm-fs-32'>Data downloads</h2>
-          <div className='clearfix mxn2'>
+          <div className='flex flex-wrap mxn2'>
             {otherDataSets.map((d, i) => (
-              <div key={i} className='sm-col sm-col-4 px2 mb2 sm-m0'>
+              <div key={i} className='flex sm-col sm-col-4 px2 mb2 sm-m0'>
                 <div className='px3 py2 bg-blue-white'>
                   <div className='mb1 pb1 fs-ch2 bold border-bottom border-red-bright'>
                     {d.title}

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -147,7 +147,7 @@ const Home = ({ appState, dispatch, location }) => {
                     {d.title}
                   </div>
                   <p className='mb2'>{d.description}</p>
-                  <button className='mb1 btn btn-primary btn-sm'>
+                  <button className='mb1 btn btn-primary btn-sm fs-14'>
                     View details
                   </button>
                 </div>

--- a/src/components/NibrsTable.js
+++ b/src/components/NibrsTable.js
@@ -3,9 +3,9 @@ import React from 'react'
 
 import DownloadDataBtn from './DownloadDataBtn'
 
-const formatPercent = p => (p > 0.01 ? format('.0%')(p) : '<1%')
 const formatNumber = format(',')
-const formatSI = format('.2s')
+const formatPercent = p => (p > 0.01 ? format('.0%')(p) : '<1%')
+const formatSI = n => (Number(n) > 10 ? format('.2s')(n) : formatNumber(n))
 
 class NibrsTable extends React.Component {
   constructor(props) {

--- a/src/components/UcrParticipationInformation.js
+++ b/src/components/UcrParticipationInformation.js
@@ -9,13 +9,13 @@ import ucrParticipation from '../util/ucr'
 const formatNumber = format(',')
 
 const UcrParticipationInformation = ({ dispatch, place, timeTo, ucr }) => {
-  const links = content.states[startCase(place)] || []
+  const links = (content.states[startCase(place)] || []).filter(l => l.text)
   const participation = ucrParticipation(place)
   const placeInfo = { ...ucr.data[place] }
 
   return (
-    <div className='mb5 clearfix fs-18 serif'>
-      <div className='sm-col sm-col-8 mb2 sm-m0 p0 sm-pr2'>
+    <div className='mb5 clearfix'>
+      <div className='sm-col sm-col-8 mb2 sm-m0 p0 sm-pr2 fs-18 serif'>
         <p>
           {startCase(place)} reports {
             (participation.hybrid && 'both')
@@ -45,7 +45,7 @@ const UcrParticipationInformation = ({ dispatch, place, timeTo, ucr }) => {
         </p>
         )}
       </div>
-      <ul className='sm-col sm-col-4 m0 p0 list-style-none'>
+      <ul className='sm-col sm-col-4 m0 p0 fs-14 list-style-none'>
         {links.map((l, i) => (
           <li key={i}>
             <a className='bold' href={l.url}>


### PR DESCRIPTION
this fixes https://github.com/18F/crime-data-explorer/issues/288 and makes the other dataset boxes on homepage have a uniform background height (regardless of content length):

<img width="1049" alt="screen shot 2017-02-14 at 11 59 10 am" src="https://cloud.githubusercontent.com/assets/1060893/22939568/1c4c5898-f2ad-11e6-8991-f3ad8cf4b5c9.png">
