### PR TITLE
Fix histogram details error when there is no data

### DIFF
--- a/src/components/Histogram.js
+++ b/src/components/Histogram.js
@@ -76,7 +76,7 @@ class Histogram extends React.Component {
             <XAxis scale={x} height={height} tickCt={binCt} />
           </g>
         </svg>
-        <HistogramDetails data={bins[active]} />
+        {bins[active] && <HistogramDetails data={bins[active]} />}
       </div>
     )
   }

--- a/src/components/Histogram.js
+++ b/src/components/Histogram.js
@@ -44,8 +44,8 @@ class Histogram extends React.Component {
         .domain([0, max(bins, d => d.ct)])
         .range([height, 0])
 
-    // default to last bin if no interaction
-    const active = hover !== null ? hover : binCt - 1
+    // default to first bin if no interaction
+    const active = hover !== null ? hover : 0
 
     return (
       <div>


### PR DESCRIPTION
I think that this should fix a bug where the Histogram details component causes the explorer view to crash while rendering. If there is no data, then the histogram will just be blank and the histogram details component will not be used.