### PR TITLE
Use explorer_offense for consistent mapping of summary offenses

### DIFF
--- a/src/util/offenses.js
+++ b/src/util/offenses.js
@@ -1,29 +1,31 @@
+import { slugify } from './text'
+
 const offenses = {
-  'aggravated-assault': 'Assault',
-  burglary: 'Burglary',
-  larceny: 'Larceny',
-  'motor-vehicle-theft': 'Moter vehicle theft',
-  homicide: 'Homicide',
+  'aggravated-assault': 'aggravated-assault',
+  burglary: 'burglary',
+  larceny: 'larceny',
+  'motor-vehicle-theft': 'motor-vehicle-theft',
+  homicide: 'homicide',
   'property-crime': 'Property',
-  rape: 'Rape',
-  robbery: 'Robbery',
+  rape: 'rape',
+  robbery: 'robbery',
   'violent-crime': 'Violent',
 }
 const ids = Object.keys(offenses)
 
 const offenseParams = {
-  'aggravated-assault': 'offense',
-  burglary: 'offense',
-  larceny: 'offense',
-  'motor-vehicle-theft': 'offense',
+  'aggravated-assault': 'explorer_offense',
+  burglary: 'explorer_offense',
+  larceny: 'explorer_offense',
+  'motor-vehicle-theft': 'explorer_offense',
   homicide: 'offense_category',
   'property-crime': 'classification',
-  rape: 'offense',
-  robbery: 'offense',
+  rape: 'explorer_offense',
+  robbery: 'explorer_offense',
   'violent-crime': 'classification',
 }
 
-const mapToApiOffense = o => offenses[o]
+const mapToApiOffense = o => offenses[o] || slugify(o)
 const mapToApiOffenseParam = o => offenseParams[o]
 
 export default ids


### PR DESCRIPTION
Uses the new `explorer_offense` parameter so that the UI -> official crime mapping can be done by the API. With this change, all of the trend charts should work for all crime types.

I will note that the NIBRS dimensions do not change to reflect "All violent crime" or "All property crime". I'll have to check through the issues to see what the expected behavior is

The API mapping can be found here:
https://github.com/18F/crime-data-api/blob/master/crime_data/common/base
.py#L507