### PR TITLE
Update UCR program participation data

### DIFF
--- a/data/ucr-program-participation.json
+++ b/data/ucr-program-participation.json
@@ -5,7 +5,9 @@
   },
   "alabama": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1991
+    }
   },
   "alaska": {
     "srs": true,
@@ -13,11 +15,15 @@
   },
   "arizona": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 2004
+    }
   },
   "arkansas": {
     "srs": false,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1999
+    }
   },
   "california": {
     "srs": true,
@@ -25,15 +31,27 @@
   },
   "colorado": {
     "srs": false,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1992
+    }
   },
   "connecticut": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1998
+    }
   },
   "delaware": {
     "srs": false,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 2001
+    }
+  },
+  "district-of-columbia": {
+    "srs": false,
+    "nibrs": {
+      "initial-year": 2000
+    }
   },
   "florida": {
     "srs": true,
@@ -49,35 +67,51 @@
   },
   "idaho": {
     "srs": false,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1992
+    }
   },
   "illinois": {
     "srs": true,
-    "nibrs": false
+    "nibrs": {
+      "initial-year": 1993
+    }
   },
   "indiana": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 2013
+    }
   },
   "iowa": {
     "srs": false,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1991
+    }
   },
   "kansas": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 2000
+    }
   },
   "kentucky": {
     "srs": false,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1998
+    }
   },
   "louisiana": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 2003
+    }
   },
   "maine": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 2003
+    }
   },
   "maryland": {
     "srs": true,
@@ -85,11 +119,15 @@
   },
   "massachusetts": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1994
+    }
   },
   "michigan": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1995
+    }
   },
   "minnesota": {
     "srs": true,
@@ -97,19 +135,27 @@
   },
   "mississippi": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 2009
+    }
   },
   "missouri": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 2006
+    }
   },
   "montana": {
     "srs": false,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 2005
+    }
   },
   "nebraska": {
     "srs": false,
-    "nibrs": false
+    "nibrs": {
+      "initial-year": 1998
+    }
   },
   "nevada": {
     "srs": true,
@@ -117,7 +163,9 @@
   },
   "new-hampshire": {
     "srs": false,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 2002
+    }
   },
   "new-jersey": {
     "srs": true,
@@ -137,67 +185,99 @@
   },
   "north-dakota": {
     "srs": false,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1991
+    }
   },
   "ohio": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1998
+    }
   },
   "oklahoma": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 2008
+    }
   },
   "oregon": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 2003
+    }
   },
   "pennsylvania": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 2012
+    }
   },
   "rhode-island": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 2004
+    }
   },
   "south-carolina": {
     "srs": false,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1991
+    }
   },
   "south-dakota": {
     "srs": false,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 2000
+    }
   },
   "tennessee": {
     "srs": false,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1997
+    }
   },
   "texas": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1997
+    }
   },
   "utah": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1993
+    }
   },
   "vermont": {
     "srs": false,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1993
+    }
   },
   "virginia": {
     "srs": false,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1994
+    }
   },
   "washington": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 2005
+    }
   },
   "west-virginia": {
     "srs": false,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 1998
+    }
   },
   "wisconsin": {
     "srs": true,
-    "nibrs": true
+    "nibrs": {
+      "initial-year": 2004
+    }
   },
   "wyoming": {
     "srs": true,

--- a/data/ucr-program-participation.json
+++ b/data/ucr-program-participation.json
@@ -1,257 +1,206 @@
 {
   "united-states": {
     "srs": true,
-    "nibrs": false,
-    "hybrid": false
+    "nibrs": false
   },
   "alabama": {
     "srs": true,
-    "nibrs": false,
-    "hybrid": false
+    "nibrs": true
   },
   "alaska": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": false
   },
   "arizona": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": true
   },
   "arkansas": {
     "srs": false,
-    "nibrs": true,
-    "hybrid": false
+    "nibrs": true
   },
   "california": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": false
   },
   "colorado": {
     "srs": false,
-    "nibrs": true,
-    "hybrid": false
+    "nibrs": true
   },
   "connecticut": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": true
   },
   "delaware": {
     "srs": false,
-    "nibrs": true,
-    "hybrid": false
+    "nibrs": true
   },
   "florida": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": false
   },
   "georgia": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": true
   },
   "hawaii": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": false
   },
   "idaho": {
     "srs": false,
-    "nibrs": true,
-    "hybrid": false
+    "nibrs": true
   },
   "illinois": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": false
   },
   "indiana": {
     "srs": true,
-    "nibrs": false,
-    "hybrid": false
+    "nibrs": true
   },
   "iowa": {
     "srs": false,
-    "nibrs": true,
-    "hybrid": false
+    "nibrs": true
   },
   "kansas": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": true
   },
   "kentucky": {
     "srs": false,
-    "nibrs": true,
-    "hybrid": false
+    "nibrs": true
   },
   "louisiana": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": true
   },
   "maine": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": true
   },
   "maryland": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": false
   },
   "massachusetts": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": true
   },
   "michigan": {
-    "srs": false,
-    "nibrs": true,
-    "hybrid": false
+    "srs": true,
+    "nibrs": true
   },
   "minnesota": {
     "srs": true,
-    "nibrs": false,
-    "hybrid": false
+    "nibrs": false
   },
   "mississippi": {
     "srs": true,
-    "nibrs": false,
-    "hybrid": false
+    "nibrs": true
   },
   "missouri": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": true
   },
   "montana": {
     "srs": false,
-    "nibrs": true,
-    "hybrid": false
+    "nibrs": true
   },
   "nebraska": {
     "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "nibrs": false
   },
   "nevada": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": false
   },
   "new-hampshire": {
     "srs": false,
-    "nibrs": true,
-    "hybrid": false
+    "nibrs": true
   },
   "new-jersey": {
     "srs": true,
-    "nibrs": false,
-    "hybrid": false
+    "nibrs": false
   },
   "new-mexico": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": false
   },
   "new-york": {
     "srs": true,
-    "nibrs": false,
-    "hybrid": false
+    "nibrs": false
   },
   "north-carolina": {
     "srs": true,
-    "nibrs": false,
-    "hybrid": false
+    "nibrs": false
   },
   "north-dakota": {
     "srs": false,
-    "nibrs": true,
-    "hybrid": false
+    "nibrs": true
   },
   "ohio": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": true
   },
   "oklahoma": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": true
   },
   "oregon": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": true
   },
   "pennsylvania": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": true
   },
   "rhode-island": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": true
   },
   "south-carolina": {
     "srs": false,
-    "nibrs": true,
-    "hybrid": false
+    "nibrs": true
   },
   "south-dakota": {
     "srs": false,
-    "nibrs": true,
-    "hybrid": false
+    "nibrs": true
   },
   "tennessee": {
     "srs": false,
-    "nibrs": true,
-    "hybrid": false
+    "nibrs": true
   },
   "texas": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": true
   },
   "utah": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": true
   },
   "vermont": {
     "srs": false,
-    "nibrs": true,
-    "hybrid": false
+    "nibrs": true
   },
   "virginia": {
-    "srs": true,
-    "nibrs": false,
-    "hybrid": false
+    "srs": false,
+    "nibrs": true
   },
   "washington": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": true
   },
   "west-virginia": {
     "srs": false,
-    "nibrs": true,
-    "hybrid": false
+    "nibrs": true
   },
   "wisconsin": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": true
   },
   "wyoming": {
-    "srs": false,
-    "nibrs": false,
-    "hybrid": true
+    "srs": true,
+    "nibrs": false
   }
 }

--- a/src/components/DownloadBulkNibrs.js
+++ b/src/components/DownloadBulkNibrs.js
@@ -6,17 +6,7 @@ import Term from './Term'
 import ucrProgram from '../../data/ucr-program-participation.json'
 import ucrStateCodes from '../../data/ucr-state-codes.json'
 
-const nibrsStates = Object.keys(ucrProgram).map(s => s).filter(s => {
-  const state = ucrProgram[s]
-  return state.nibrs || state.hybrid
-}).map(s => ({
-  text: startCase(s),
-  value: ucrStateCodes[s],
-}))
-
-const firstYear = 2000
-const numberOfYears = 15
-const nibrsYears = range(numberOfYears).map(x => x + firstYear)
+const nibrsStates = Object.keys(ucrProgram).filter(s => ucrProgram[s].nibrs)
 
 const bulkNibrs = 'http://s3-us-gov-west-1.amazonaws.com/cg-d3f0433b-a53e-4934-8b94-c678aa2cbaf3'
 const createBulkNibrsUrl = (year, state) => {
@@ -38,14 +28,23 @@ class DownloadBulkNibrs extends React.Component {
       year: null,
     }
 
+    this.getYearRange = ::this.getYearRange
     this.handleClick = ::this.handleClick
     this.handleSelectChange = ::this.handleSelectChange
+  }
+
+  getYearRange() {
+    if (!this.state.place) return []
+    const { nibrs } = ucrProgram[this.state.place]
+    const initialYear = nibrs['initial-year']
+
+    return range((2014 + 1) - initialYear).map(y => initialYear + y)
   }
 
   handleClick(e) {
     e.preventDefault()
     const { place, year } = this.state
-    downloadBulkNibrs(year, place)
+    downloadBulkNibrs(year, ucrStateCodes[place])
   }
 
   handleSelectChange(e) {
@@ -69,6 +68,7 @@ class DownloadBulkNibrs extends React.Component {
         incident-based (NIBRS)
       </Term>
     )
+    const nibrsYears = this.getYearRange(this.state.place)
 
     return (
       <div className='mb8'>
@@ -90,7 +90,7 @@ class DownloadBulkNibrs extends React.Component {
               >
                 <option disabled selected>Select a place</option>
                 {nibrsStates.map((s, i) => (
-                  <option key={i} value={s.value}>{s.text}</option>
+                  <option key={i} value={s}>{startCase(s)}</option>
                 ))}
               </select>
             </div>

--- a/src/components/NibrsContainer.js
+++ b/src/components/NibrsContainer.js
@@ -10,12 +10,12 @@ import parseNibrs from '../util/nibrs'
 const fbiLink = 'https://ucr.fbi.gov/ucr-program-data-collections'
 const formatNumber = format(',')
 
-const NibrsContainer = ({ crime, data, error, filters, place }) => {
+const NibrsContainer = ({ crime, data, error, filters, loading, place }) => {
   const { timeFrom, timeTo } = filters
   let totalCount
 
   let content = <Loading />
-  if (data) {
+  if (!loading && data) {
     const dataParsed = parseNibrs(data)
     totalCount = data.offenderRaceCode.reduce((a, b) => (a + b.count), 0)
     content = (

--- a/test/util/ucr.test.js
+++ b/test/util/ucr.test.js
@@ -7,7 +7,7 @@ describe('ucr utility', () => {
     const place = 'california'
     const actual = dataSourcesReportedByState(place)
 
-    expect(Object.keys(actual).length).toEqual(3)
+    expect(Object.keys(actual).length).toEqual(2)
   })
 
   it('should return null for a value that doesn\'t exist', () => {


### PR DESCRIPTION
Update the types of data that each state submits to the UCR program. Having a `true` value for a type of data means that the state DOES submit that data. Therefore, the "hybrid" key has been converted into a derived state when both `srs` and `nibrs` are submitted.

@brendansudol I think this will be useful for creating the participation map on the About page