### PR TITLE
Update other dataset links

### DIFF
--- a/content/datasets.yml
+++ b/content/datasets.yml
@@ -1,7 +1,7 @@
 - title: Hate Crime
   description: |
     See totals by state, year, and bias motivation for hate crimes across the country since 1991.
-  download: 'https://www.bagelblog.nyc'
+  download: 'http://s3-us-gov-west-1.amazonaws.com/cg-d3f0433b-a53e-4934-8b94-c678aa2cbaf3/other/hate_crime'
 - title: Law Enforcement Officers Killed and Assaulted (LEOKA)
   description: |
     See totals for officers who were killed or assaulted in the line of duty since 1974.
@@ -9,16 +9,16 @@
 - title: Police Employee Data
   description: |
     See how many full-time sworn and civilian law enforcement employees serve in your community.
-  download: 'https://www.bagelblog.nyc'
+  download: 'http://s3-us-gov-west-1.amazonaws.com/cg-d3f0433b-a53e-4934-8b94-c678aa2cbaf3/other/pe_employment'
 - title: Uniform Crime Reporting Program Participation Data
   description: |
     See how many law enforcement agencies have participated in the UCR Program by state and year.
-  download: 'https://www.bagelblog.nyc'
+  download: 'http://s3-us-gov-west-1.amazonaws.com/cg-d3f0433b-a53e-4934-8b94-c678aa2cbaf3/other/ucr_participation'
 - title: Cargo Theft
   description: |
     See totals by state, year, property type, and property value for cargo thefts since 2013.
-  download: 'https://www.bagelblog.nyc'
+  download: 'http://s3-us-gov-west-1.amazonaws.com/cg-d3f0433b-a53e-4934-8b94-c678aa2cbaf3/other/cargo_theft'
 - title: Human Trafficking
   description: |
     See totals by state and offense for commercial sex acts and involuntary servitude since 2013.
-  download: 'https://www.bagelblog.nyc'
+  download: 'http://s3-us-gov-west-1.amazonaws.com/cg-d3f0433b-a53e-4934-8b94-c678aa2cbaf3/other/human_trafficking'


### PR DESCRIPTION
I updated the URLs for the datasets based on [this comment in 237](https://github.com/18F/crime-data-explorer/issues/237#issuecomment-282077346), but this shouldn't be merged until the files are put on S3.