### PR TITLE
HOTFIX: Remove old term code from <TrendContainer />

### DIFF
--- a/src/components/TrendContainer.js
+++ b/src/components/TrendContainer.js
@@ -8,11 +8,6 @@ import TrendSourceText from './TrendSourceText'
 
 const TrendContainer = ({ crime, place, filters, data, dispatch, loading, keys }) => {
   const { timeFrom, timeTo } = filters
-  const srs = (
-    <Term id='summary reporting system (srs)' dispatch={dispatch}>
-      Summary (SRS)
-    </Term>
-  )
 
   let content = null
   if (loading) content = <Loading />


### PR DESCRIPTION
I poorly resolved a merge conflict and ended up crashing the app since it was trying to use the <Term /> component in a container where it was not defined.