### PR TITLE
fix 470

### DIFF
--- a/sass/components/_tooltips.scss
+++ b/sass/components/_tooltips.scss
@@ -1,0 +1,112 @@
+// subset of hint.css
+// scss-lint:disable ImportantRule,MergeableSelector,PropertySortOrder
+// scss-lint:disable PseudoElement,VendorPrefix
+
+[class*="hint--"] {
+  position: relative;
+  display: inline-block;
+}
+
+[class*="hint--"]:before,
+[class*="hint--"]:after {
+  position: absolute;
+  -webkit-transform: translate3d(0, 0, 0);
+  -moz-transform: translate3d(0, 0, 0);
+  transform: translate3d(0, 0, 0);
+  visibility: hidden;
+  opacity: 0;
+  z-index: 1000000;
+  pointer-events: none;
+  transition: .3s ease;
+  transition-delay: 0ms;
+}
+
+[class*="hint--"]:hover:before,
+[class*="hint--"]:hover:after {
+  visibility: visible;
+  opacity: 1;
+}
+
+[class*="hint--"]:hover:before,
+[class*="hint--"]:hover:after {
+  -webkit-transition-delay: 100ms;
+  -moz-transition-delay: 100ms;
+  transition-delay: 100ms;
+}
+
+[class*="hint--"]:before {
+  content: '';
+  position: absolute;
+  background: transparent;
+  border: 6px solid transparent;
+  z-index: 1000001;
+}
+
+[class*="hint--"]:after {
+  background: #383838;
+  border-radius: $border-radius;
+  color: $white;
+  padding: 8px 10px;
+  font-size: 12px;
+  font-family: $font-sans-serif;
+  line-height: 12px;
+  white-space: nowrap;
+}
+
+[class*="hint--"][aria-label]:after {
+  content: attr(aria-label);
+}
+
+[class*="hint--"][data-hint]:after {
+  content: attr(data-hint);
+}
+
+[aria-label='']:before,
+[aria-label='']:after,
+[data-hint='']:before,
+[data-hint='']:after {
+  display: none !important;
+}
+
+.hint--bottom:before {
+  border-bottom-color: #383838;
+}
+
+.hint--bottom:before {
+  margin-top: -11px;
+}
+
+.hint--bottom:before,
+.hint--bottom:after {
+  top: 100%;
+  left: 50%;
+}
+
+.hint--bottom:before {
+  left: calc(50% - 6px);
+}
+
+.hint--bottom:after {
+  -webkit-transform: translateX(-50%);
+  -moz-transform: translateX(-50%);
+  transform: translateX(-50%);
+}
+
+.hint--bottom:hover:before {
+  -webkit-transform: translateY(8px);
+  -moz-transform: translateY(8px);
+  transform: translateY(8px);
+}
+
+.hint--bottom:hover:after {
+  -webkit-transform: translateX(-50%) translateY(8px);
+  -moz-transform: translateX(-50%) translateY(8px);
+  transform: translateX(-50%) translateY(8px);
+}
+
+.hint--no-animate:before,
+.hint--no-animate:after {
+  -webkit-transition-duration: 0ms;
+  -moz-transition-duration: 0ms;
+  transition-duration: 0ms;
+}

--- a/sass/components/_tooltips.scss
+++ b/sass/components/_tooltips.scss
@@ -2,13 +2,13 @@
 // scss-lint:disable ImportantRule,MergeableSelector,PropertySortOrder
 // scss-lint:disable PseudoElement,VendorPrefix
 
-[class*="hint--"] {
+[class*="hint-"] {
   position: relative;
   display: inline-block;
 }
 
-[class*="hint--"]:before,
-[class*="hint--"]:after {
+[class*="hint-"]:before,
+[class*="hint-"]:after {
   position: absolute;
   -webkit-transform: translate3d(0, 0, 0);
   -moz-transform: translate3d(0, 0, 0);
@@ -21,20 +21,20 @@
   transition-delay: 0ms;
 }
 
-[class*="hint--"]:hover:before,
-[class*="hint--"]:hover:after {
+[class*="hint-"]:hover:before,
+[class*="hint-"]:hover:after {
   visibility: visible;
   opacity: 1;
 }
 
-[class*="hint--"]:hover:before,
-[class*="hint--"]:hover:after {
+[class*="hint-"]:hover:before,
+[class*="hint-"]:hover:after {
   -webkit-transition-delay: 100ms;
   -moz-transition-delay: 100ms;
   transition-delay: 100ms;
 }
 
-[class*="hint--"]:before {
+[class*="hint-"]:before {
   content: '';
   position: absolute;
   background: transparent;
@@ -42,7 +42,7 @@
   z-index: 1000001;
 }
 
-[class*="hint--"]:after {
+[class*="hint-"]:after {
   background: #383838;
   border-radius: $border-radius;
   color: $white;
@@ -53,11 +53,11 @@
   white-space: nowrap;
 }
 
-[class*="hint--"][aria-label]:after {
+[class*="hint-"][aria-label]:after {
   content: attr(aria-label);
 }
 
-[class*="hint--"][data-hint]:after {
+[class*="hint-"][data-hint]:after {
   content: attr(data-hint);
 }
 
@@ -68,44 +68,44 @@
   display: none !important;
 }
 
-.hint--bottom:before {
+.hint-bottom:before {
   border-bottom-color: #383838;
 }
 
-.hint--bottom:before {
+.hint-bottom:before {
   margin-top: -11px;
 }
 
-.hint--bottom:before,
-.hint--bottom:after {
+.hint-bottom:before,
+.hint-bottom:after {
   top: 100%;
   left: 50%;
 }
 
-.hint--bottom:before {
+.hint-bottom:before {
   left: calc(50% - 6px);
 }
 
-.hint--bottom:after {
+.hint-bottom:after {
   -webkit-transform: translateX(-50%);
   -moz-transform: translateX(-50%);
   transform: translateX(-50%);
 }
 
-.hint--bottom:hover:before {
+.hint-bottom:hover:before {
   -webkit-transform: translateY(8px);
   -moz-transform: translateY(8px);
   transform: translateY(8px);
 }
 
-.hint--bottom:hover:after {
+.hint-bottom:hover:after {
   -webkit-transform: translateX(-50%) translateY(8px);
   -moz-transform: translateX(-50%) translateY(8px);
   transform: translateX(-50%) translateY(8px);
 }
 
-.hint--no-animate:before,
-.hint--no-animate:after {
+.hint-no-animate:before,
+.hint-no-animate:after {
   -webkit-transition-duration: 0ms;
   -moz-transition-duration: 0ms;
   transition-duration: 0ms;

--- a/sass/components/all.scss
+++ b/sass/components/all.scss
@@ -7,4 +7,5 @@
 @import 'list';
 @import 'progress';
 @import 'tables';
+@import 'tooltips';
 @import 'viz';

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -101,7 +101,7 @@ const Home = ({ appState, dispatch, location }) => {
             </div>
             <div className='sm-col sm-col-4 px2 mb2 sm-m0 xs-hide'>
               <button
-                className={`col-12 btn btn-primary ${isValid ? '' : 'hint--bottom'}`}
+                className={`col-12 btn btn-primary ${isValid ? '' : 'hint-bottom'}`}
                 aria-label={isValid ? '' : 'Please select a location and crime type'}
                 disabled={!isValid}
                 onClick={handleSearchClick}

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -14,21 +14,24 @@ import otherDataSets from '../../content/datasets.yml'
 
 const Home = ({ appState, dispatch, location }) => {
   const { crime, place } = appState.filters
-  const isButtonDisabled = !!(crime && place) || false
+  const isValid = !!(crime && place) || false
 
   const handleMapClick = e => {
     const id = e.target.getAttribute('id')
     if (!id) return
     dispatch(updateFilters({ place: slugify(stateLookup(id)) }))
   }
+
   const handleSearchClick = () => {
     const change = { crime, place }
     dispatch(updateApp(change, location))
   }
+
   const selectCrime = e => {
     const action = updateFilters({ crime: slugify(e.target.value) })
     dispatch(action)
   }
+
   const selectLocation = e => dispatch(updateFilters(e))
 
   return (
@@ -98,8 +101,9 @@ const Home = ({ appState, dispatch, location }) => {
             </div>
             <div className='sm-col sm-col-4 px2 mb2 sm-m0 xs-hide'>
               <button
-                className='col-12 btn btn-primary'
-                disabled={!isButtonDisabled}
+                className={`col-12 btn btn-primary ${isValid ? '' : 'hint--bottom'}`}
+                aria-label={isValid ? '' : 'Please select a location and crime type'}
+                disabled={!isValid}
                 onClick={handleSearchClick}
               >
                 View results
@@ -112,7 +116,7 @@ const Home = ({ appState, dispatch, location }) => {
           <div className='mb7 sm-hide md-hide lg-hide'>
             <button
               className='btn btn-primary'
-              disabled={!isButtonDisabled}
+              disabled={!isValid}
               onClick={handleSearchClick}
             >
               View results


### PR DESCRIPTION
I propose this as a solution to https://github.com/18F/crime-data-explorer/issues/470

When either of the two inputs (place and crime) is not selected and one hovers / clicks on submit button, you get a tooltip that says to make sure you choose a place & crime.

<img width="800" alt="screen shot 2017-03-06 at 12 16 33 pm" src="https://cloud.githubusercontent.com/assets/1060893/23621149/8b54d0ac-0267-11e7-8089-9cfe880f6b34.png">  

While not exactly like the design, this is a simpler implementation and perhaps accomplishes the desired effect for the user

thoughts @jeremiak @AvivaOskow ?