### PR TITLE
Show beta banner on all devices/displays

### DIFF
--- a/src/components/Disclaimer.js
+++ b/src/components/Disclaimer.js
@@ -12,10 +12,10 @@ const Disclaimer = () => (
       />
       An official website of the United States government
     </div>
-    <div className='sm-col-right xs-hide'>
-      <span className='mr2 red bold'>This site is in beta.&nbsp;</span>
+    <div className='flex sm-col-right items-center justify-between '>
+      <span className='ml1 mr2 red bold'>This site is in beta.&nbsp;</span>
       <a
-        className='px5 py1 inline-block bold caps white bg-red'
+        className='bg-red bold caps inline-block px5 py1 white'
         href='https://github.com/18F/crime-data-explorer/issues'
       >
         Feedback


### PR DESCRIPTION
Fixes https://github.com/18F/crime-data-api/issues/378

![beta-banner-responsive](https://cloud.githubusercontent.com/assets/780941/23626650/7bbdc7de-0262-11e7-9e1b-0614344b0788.gif)
