### PR TITLE
Change data download names

### DIFF
--- a/src/components/DownloadDataBtn.js
+++ b/src/components/DownloadDataBtn.js
@@ -1,9 +1,10 @@
 import React from 'react'
 
 import jsonToCsv from '../util/csv'
+import { slugify } from '../util/text'
 
 const downloadData = (fname, data) => {
-  const file = `${fname}.csv`
+  const file = `${slugify(fname)}.csv`
   const dataStr = jsonToCsv(data)
 
   if (window.navigator.msSaveBlob) {
@@ -52,6 +53,13 @@ const DownloadDataBtn = ({ data, fname, text, url }) => {
       {text}
     </button>
   )
+}
+
+DownloadDataBtn.propTypes = {
+  data: React.PropTypes.arrayOf(React.PropTypes.object),
+  fname: React.PropTypes.string.isRequired,
+  text: React.PropTypes.string.isRequired,
+  url: React.PropTypes.string,
 }
 
 export default DownloadDataBtn

--- a/src/components/NibrsCard.js
+++ b/src/components/NibrsCard.js
@@ -1,11 +1,12 @@
 import pluralize from 'pluralize'
 import React from 'react'
 
+import DownloadDataBtn from './DownloadDataBtn'
 import NibrsDonut from './NibrsDonut'
 import NibrsHistogram from './NibrsHistogram'
 import NibrsTable from './NibrsTable'
 
-const NibrsCard = ({ data, title }) => {
+const NibrsCard = ({ crime, data, place, title }) => {
   const charts = data.map((d, i) => {
     const props = { key: i, ...d }
     switch (d.type) {
@@ -35,12 +36,19 @@ const NibrsCard = ({ data, title }) => {
           <span className='bold fs-14 ml1 monospace'>0</span>
         </div>
       )}
+      <DownloadDataBtn
+        data={data[0].data.map(d => ({ key: d.key, count: d.count }))}
+        fname={`${place}-${crime}-${data[0].title || title}`}
+        text='Download data'
+      />
     </div>
   )
 }
 
 NibrsCard.propTypes = {
+  crime: React.PropTypes.string,
   data: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+  place: React.PropTypes.string,
   title: React.PropTypes.string.isRequired,
 }
 

--- a/src/components/NibrsContainer.js
+++ b/src/components/NibrsContainer.js
@@ -44,7 +44,7 @@ const NibrsContainer = ({
             key={i}
             className={`lg-col lg-col-6 mb2 px1 ${i % 2 === 0 ? 'clear-left' : ''}`}
           >
-            <NibrsCard {...d} />
+            <NibrsCard crime={crime} place={place} {...d} />
           </div>
         ))}
       </div>

--- a/src/components/NibrsTable.js
+++ b/src/components/NibrsTable.js
@@ -2,8 +2,6 @@ import { format } from 'd3-format'
 import pluralize from 'pluralize'
 import React from 'react'
 
-import DownloadDataBtn from './DownloadDataBtn'
-
 const formatNumber = format(',')
 const formatPercent = p => (p > 0.01 ? format('.0%')(p) : '<1%')
 const formatSI = n => (Number(n) > 10 ? format('.2s')(n) : formatNumber(n))
@@ -109,11 +107,6 @@ class NibrsTable extends React.Component {
               %
             </button>
           </div>
-          <DownloadDataBtn
-            data={data.map(d => ({ key: d.key, count: d.count }))}
-            fname={title}
-            text='Download data'
-          />
         </div>
       </div>
     )


### PR DESCRIPTION
The download button should give the user data from the entire card, not
just the last table component. I moved the data download button out and
into the NibrsCard, passing in the crime and place name so the
downloaded file has a useful name.

Right now the data download button only returns the first item in the
data array, but it should actually trigger multiple downloads if there
are multiple datasets inside of the nibrs card.

Noticed that the nibrs demographic data download is only one out of the three expected CSVs so I opened #538 for that.

Refs #501 