### PR TITLE
Set minimum height for NIBRS histogram details

### DIFF
--- a/sass/util/_height.scss
+++ b/sass/util/_height.scss
@@ -1,0 +1,1 @@
+.mh6 { min-height: $space-6; }

--- a/sass/util/all.scss
+++ b/sass/util/all.scss
@@ -4,6 +4,7 @@
 @import 'colors';
 @import 'cursor';
 @import 'display';
+@import 'height';
 @import 'layout';
 @import 'line-height';
 @import 'space-addon';

--- a/src/components/NibrsHistogramDetails.js
+++ b/src/components/NibrsHistogramDetails.js
@@ -8,7 +8,7 @@ const NibrsHistogramDetails = ({ data, noun }) => {
   const highlight = v => <span className='bold red'>{v}</span>
 
   return (
-    <div className='mt1 fs-14'>
+    <div className='mh6 mt1 fs-14'>
       There were {highlight(fmt(data.ct))} incidents
       involving {pluralize(noun)} aged {highlight(`${data.x0}-${data.x1 - 1}`)}.
     </div>


### PR DESCRIPTION
Before:
![nibrs-no-min-height](https://cloud.githubusercontent.com/assets/780941/23721476/c2211600-03f6-11e7-850a-cd43f9ab055d.gif)

After:
![nibrs-details-min-height](https://cloud.githubusercontent.com/assets/780941/23721484/c7387e08-03f6-11e7-87b6-d52854bc2d29.gif)

Refs #449 