### PR TITLE
Fix state thumbnails

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "scripts": {
     "start": "node build/server.js",
-    "build": "npm run build:client && npm run build:server",
+    "build": "export NODE_ENV=production && npm run build:client && npm run build:server",
     "build:client": "webpack -p --progress --config webpack.client.config.js",
-    "build:server": "webpack --config webpack.server.config.js",
+    "build:server": "webpack -p --config webpack.server.config.js",
     "watch": "npm run watch:server & npm run watch:client",
     "watch:server": "webpack -w --config webpack.server.config.js & nodemon build/server.js",
     "watch:client": "webpack -w --progress --config webpack.client.config.js",

--- a/src/components/StateThumbnail.js
+++ b/src/components/StateThumbnail.js
@@ -1,7 +1,8 @@
-import axios from 'axios'
 import { geoAlbersUsa, geoPath } from 'd3-geo'
 import React from 'react'
 import { feature, mesh } from 'topojson'
+
+import data from '../../data/geo-usa-states.json'
 
 const Container = ({ children }) => (
   <div className='aspect-ratio aspect-ratio--4x3'>{children}</div>
@@ -10,12 +11,7 @@ const Container = ({ children }) => (
 class StateThumbnail extends React.Component {
   constructor(props) {
     super(props)
-    this.state = { usa: null }
-  }
-
-  componentDidMount() {
-    axios.get('/data/geo-usa-states.json')
-      .then(response => { this.setState({ usa: response.data }) })
+    this.state = { usa: data }
   }
 
   render() {


### PR DESCRIPTION
Instead of fetching the json through ajax, I set the <StateThumbnail /> to import the data and use it immediately. This also helps prevent us from having to move the data files around to ensure that they are available through the express server.