### PR TITLE
Build JS for production

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "start": "node build/server.js",
-    "build": "npm run build:client && npm run build:server",
+    "build": "export NODE_ENV=production && npm run build:client && npm run build:server",
     "build:client": "webpack -p --progress --config webpack.client.config.js",
     "build:server": "webpack --config webpack.server.config.js",
     "watch": "npm run watch:server & npm run watch:client",


### PR DESCRIPTION
Get rid of error in `master` deploy environment that says react isn't minified for production.