### PR TITLE
Ensure that filters with bad place or crime values are ignored

### DIFF
--- a/src/actions/filters.js
+++ b/src/actions/filters.js
@@ -9,16 +9,8 @@ export const resetFilter = ({ id }) => ({ type: FILTER_RESET, id })
 export const updateFilters = filters => {
   const f = { ...filters }
 
-  if (f.crime && !isValidCrime(f.crime)) {
-    delete f.crime
-  }
+  if (f.crime && !isValidCrime(f.crime)) delete f.crime
+  if (f.place && !isValidPlace(f.place)) delete f.place
 
-  if (f.place && !isValidPlace(f.place)) {
-    delete f.place
-  }
-
-  return {
-    type: FILTERS_UPDATE,
-    filters: f,
-  }
+  return { type: FILTERS_UPDATE, filters: f }
 }

--- a/src/actions/filters.js
+++ b/src/actions/filters.js
@@ -1,4 +1,24 @@
 import { FILTER_RESET, FILTERS_UPDATE } from './constants'
+import lookupUsa from '../util/usa'
+import offenses from '../util/offenses'
+
+const isValidCrime = crime => offenses.includes(crime)
+const isValidPlace = place => lookupUsa(place)
 
 export const resetFilter = ({ id }) => ({ type: FILTER_RESET, id })
-export const updateFilters = filters => ({ type: FILTERS_UPDATE, filters })
+export const updateFilters = filters => {
+  const f = { ...filters }
+
+  if (f.crime && !isValidCrime(f.crime)) {
+    delete f.crime
+  }
+
+  if (f.place && !isValidPlace(f.place)) {
+    delete f.place
+  }
+
+  return {
+    type: FILTERS_UPDATE,
+    filters: f,
+  }
+}

--- a/test/actions/filters.test.js
+++ b/test/actions/filters.test.js
@@ -19,9 +19,28 @@ describe('filters actions', () => {
 
   describe('updateFilters()', () => {
     it('should return a FILTERS_UPDATE action', () => {
-      const actual = updateFilters({ 'fake-id': 'fake-value' })
+      const actual = updateFilters({ place: 'california', crime: 'robbery' })
       expect(actual.type).toEqual(FILTERS_UPDATE)
-      expect(Object.keys(actual.filters).length).toEqual(1)
+      expect(actual.filters.place).toEqual('california')
+      expect(actual.filters.crime).toEqual('robbery')
+    })
+
+    it('should not include unknown places in the action', () => {
+      const actual = updateFilters({ place: 'fake-place' })
+      expect(actual.type).toEqual(FILTERS_UPDATE)
+      expect(actual.filters.place).toEqual(undefined)
+    })
+
+    it('should not include unknown crimes in the action', () => {
+      const actual = updateFilters({ crime: 'fake-crime' })
+      expect(actual.type).toEqual(FILTERS_UPDATE)
+      expect(actual.filters.crime).toEqual(undefined)
+    })
+
+    it('should work without any filters passed in', () => {
+      const actual = updateFilters({})
+      expect(actual.type).toEqual(FILTERS_UPDATE)
+      expect(actual.filters).toEqual({})
     })
   })
 })


### PR DESCRIPTION
Before updating filters, check to make sure the `crime` and `place` filters are valid. If they are not, remove them