### PR TITLE
Check values before triggering API fetches

### DIFF
--- a/src/util/ucr.js
+++ b/src/util/ucr.js
@@ -5,23 +5,20 @@ import { slugify } from './text'
 
 const lookup = state => data[slugify(state)]
 
-const isValidCrime = crime => offenses.includes(crime)
 const isValidPlace = place => lookupUsa(place)
+const isValidCrime = crime => offenses.includes(crime)
+const noNibrs = ['violent-crime', 'property-crime']
 
-export const shouldFetchUcr = ({ place }) => {
-  if (!isValidPlace(place) || place === nationalKey) return false
-  return true
-}
+export const shouldFetchUcr = ({ place }) => (
+  !!(isValidPlace(place) && place !== nationalKey)
+)
 
 export const shouldFetchSummaries = ({ crime, place }) => (
   isValidCrime(crime) && isValidPlace(place)
 )
 
-const noNibrs = ['violent-crime', 'property-crime']
-
 export const shouldFetchNibrs = ({ crime, place }) => {
-  if (noNibrs.includes(crime)) return false
-  if (!isValidPlace(place)) return false
+  if (noNibrs.includes(crime) || !isValidPlace(place)) return false
   const coverage = lookup(place)
   return coverage && coverage.nibrs
 }

--- a/src/util/ucr.js
+++ b/src/util/ucr.js
@@ -17,7 +17,10 @@ export const shouldFetchSummaries = ({ crime, place }) => (
   isValidCrime(crime) && isValidPlace(place)
 )
 
-export const shouldFetchNibrs = ({ place }) => {
+const noNibrs = ['violent-crime', 'property-crime']
+
+export const shouldFetchNibrs = ({ crime, place }) => {
+  if (noNibrs.includes(crime)) return false
   if (!isValidPlace(place)) return false
   const coverage = lookup(place)
   return coverage && coverage.nibrs

--- a/src/util/ucr.js
+++ b/src/util/ucr.js
@@ -1,15 +1,24 @@
 import data from '../../data/ucr-program-participation.json'
-import lookupUsa, { nationalKey } from '../util/usa'
+import lookupUsa, { nationalKey } from './usa'
+import offenses from './offenses'
 import { slugify } from './text'
 
 const lookup = state => data[slugify(state)]
 
+const isValidCrime = crime => offenses.includes(crime)
+const isValidPlace = place => lookupUsa(place)
+
 export const shouldFetchUcr = ({ place }) => {
-  if (!lookupUsa(place) || place === nationalKey) return false
+  if (!isValidPlace(place) || place === nationalKey) return false
   return true
 }
-export const shouldFetchSummaries = ({ crime, place }) => crime && place
+
+export const shouldFetchSummaries = ({ crime, place }) => (
+  isValidCrime(crime) && isValidPlace(place)
+)
+
 export const shouldFetchNibrs = ({ place }) => {
+  if (!isValidPlace(place)) return false
   const coverage = lookup(place)
   return coverage && coverage.nibrs
 }

--- a/src/util/ucr.js
+++ b/src/util/ucr.js
@@ -1,10 +1,13 @@
 import data from '../../data/ucr-program-participation.json'
-import { nationalKey } from '../util/usa'
+import lookupUsa, { nationalKey } from '../util/usa'
 import { slugify } from './text'
 
 const lookup = state => data[slugify(state)]
 
-export const shouldFetchUcr = ({ place }) => place !== nationalKey
+export const shouldFetchUcr = ({ place }) => {
+  if (!lookupUsa(place) || place === nationalKey) return false
+  return true
+}
 export const shouldFetchSummaries = ({ crime, place }) => crime && place
 export const shouldFetchNibrs = ({ place }) => {
   const coverage = lookup(place)

--- a/test/util/ucr.test.js
+++ b/test/util/ucr.test.js
@@ -62,6 +62,12 @@ describe('ucr utility', () => {
   })
 
   describe('shouldFetchNibrs()', () => {
+    it('should return false for all violent crime', () => {
+      const filters = { place: 'montana', crime: 'violent-crime' }
+      const result = shouldFetchNibrs(filters)
+      expect(result).toEqual(false)
+    })
+
     it('should return false if place does not exist', () => {
       const result = shouldFetchNibrs({ place: 'fake-place' })
       expect(result).toEqual(false)

--- a/test/util/ucr.test.js
+++ b/test/util/ucr.test.js
@@ -32,6 +32,11 @@ describe('ucr utility', () => {
       const result = shouldFetchUcr({ place: 'montana' })
       expect(result).toEqual(true)
     })
+
+    it('should return false for invalid state names', () => {
+      const result = shouldFetchUcr({ place: 'not-a-place' })
+      expect(result).toEqual(false)
+    })
   })
 
   describe('shouldFetchSummaries()', () => {

--- a/test/util/ucr.test.js
+++ b/test/util/ucr.test.js
@@ -40,9 +40,19 @@ describe('ucr utility', () => {
   })
 
   describe('shouldFetchSummaries()', () => {
-    it('should return undefined if crime or place are missing', () => {
+    it('should return false if crime or place are missing', () => {
       const result = shouldFetchSummaries({ place: nationalKey })
-      expect(result).toEqual(undefined)
+      expect(result).toEqual(false)
+    })
+
+    it('should return false if crime is not valid', () => {
+      const result = shouldFetchSummaries({ crime: 'fake-crime' })
+      expect(result).toEqual(false)
+    })
+
+    it('should return false if place is not valid', () => {
+      const result = shouldFetchSummaries({ place: 'fake-place' })
+      expect(result).toEqual(false)
     })
 
     it('should return a truthy value if crime and place are present', () => {
@@ -52,6 +62,11 @@ describe('ucr utility', () => {
   })
 
   describe('shouldFetchNibrs()', () => {
+    it('should return false if place does not exist', () => {
+      const result = shouldFetchNibrs({ place: 'fake-place' })
+      expect(result).toEqual(false)
+    })
+
     it('should return false if place does not submit NIBRS', () => {
       const result = shouldFetchNibrs({ place: 'new-york' })
       expect(result).toEqual(false)


### PR DESCRIPTION
Check to make sure `place` and `crime` are valid and known before using them to trigger some UCR-related API calls.

Now that we have SSR and `window.__STATE__` is generated on the server, we should be more careful about using values right from the URL without checking them first. At the very least, this results in lots of errors from API calls that aren't valid.