### PR TITLE
Animate sidebar sliding in and out

### DIFF
--- a/sass/components/_layout.scss
+++ b/sass/components/_layout.scss
@@ -44,17 +44,29 @@ footer {
 }
 
 @media #{$breakpoint-max-md} {
-  .site-sidebar.open {
+  .site-sidebar {
+    animation-timing-function: ease-in;
+    animation-fill-mode: forwards;
+    animation-duration: 400ms;
     bottom: 0;
     box-sizing: border-box;
     display: block;
-    left: 0;
     max-width: 90%;
+    opacity: 0;
     overflow-y: auto;
     position: fixed;
     top: 0;
+    transform: translate(-100%, 0);
     width: $sidebar-width;
     z-index: 1;
+  }
+
+  .site-sidebar.has-opened:not(.open) {
+    animation-name: slideout;
+  }
+
+  .site-sidebar.open {
+    animation-name: slidein;
   }
 }
 

--- a/sass/util/_animations.scss
+++ b/sass/util/_animations.scss
@@ -1,0 +1,30 @@
+@keyframes slidein {
+  from {
+    transform: translate(-100%, 0);
+    opacity: 0;
+  }
+  1% {
+    opacity: 1;
+  }
+
+  to {
+    transform: translate(0, 0);
+    opacity: 1;
+  }
+}
+
+@keyframes slideout {
+  from {
+    transform: translate(0, 0);
+    opacity: 1;
+  }
+
+  99% {
+    opacity: 1;
+  }
+
+  to {
+    transform: translate(-100%, 0);
+    opacity: 0;
+  }
+}

--- a/sass/util/all.scss
+++ b/sass/util/all.scss
@@ -1,4 +1,5 @@
 @import 'align';
+@import 'animations';
 @import 'aspect-ratio';
 @import 'border';
 @import 'colors';

--- a/src/components/Explorer.js
+++ b/src/components/Explorer.js
@@ -60,6 +60,10 @@ class Explorer extends React.Component {
     this.props = props
     this.handleSidebarChange = ::this.handleSidebarChange
     this.toggleSidebar = ::this.toggleSidebar
+
+    this.state = {
+      sidebarHasOpened: false,
+    }
   }
 
   componentDidMount() {
@@ -91,12 +95,15 @@ class Explorer extends React.Component {
     const { dispatch } = this.props
     const { isOpen } = this.props.appState.sidebar
 
+    this.setState({ sidebarHasOpened: true })
+
     if (isOpen) return dispatch(hideSidebar())
     return dispatch(showSidebar())
   }
 
   render() {
     const { appState, dispatch, params, router } = this.props
+    const { sidebarHasOpened } = this.state
     const { crime, place } = params
 
     // show not found page if crime or place unfamiliar
@@ -131,6 +138,7 @@ class Explorer extends React.Component {
         <Sidebar
           dispatch={dispatch}
           filters={filters}
+          hasOpened={sidebarHasOpened}
           isOpen={sidebar.isOpen}
           onChange={this.handleSidebarChange}
           router={router}

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -7,12 +7,13 @@ import TimePeriodFilter from './TimePeriodFilter'
 
 import { hideSidebar } from '../actions/sidebar'
 
-const Sidebar = ({ dispatch, filters, isOpen, onChange, router }) => {
+const Sidebar = ({ dispatch, filters, hasOpened, isOpen, onChange, router }) => {
   const { crime, place } = router.params
   const hide = () => dispatch(hideSidebar())
+  const cls = `${isOpen && 'open'} ${hasOpened && 'has-opened'}`
 
   return (
-    <nav className={`site-sidebar bg-white ${isOpen ? 'open' : ''}`}>
+    <nav className={`site-sidebar bg-white ${cls}`}>
       <div className='p2 bg-red-bright line-height-1 md-hide lg-hide'>
         <button
           type='button'
@@ -48,6 +49,7 @@ const Sidebar = ({ dispatch, filters, isOpen, onChange, router }) => {
 }
 
 Sidebar.propTypes = {
+  hasOpened: React.PropTypes.bool,
   onChange: React.PropTypes.func,
 }
 


### PR DESCRIPTION
Proposal to use CSS animations to animate the sidebar coming in and out of the view, based off (and therefore should be merged after, if at all, #579):
<img src="https://cloud.githubusercontent.com/assets/780941/23928125/64ca2e4e-08f4-11e7-8621-d3c64a46d343.gif" alt="sidebar animation" width="200px">


Had to add the `sidebarHasOpened` to the state of the `<Explorer />` so that the slideout animation would not be applied on the initial load. I think this is pretty hacky, and might be so hacky that we'd rather not have the sidebar slide in and out.