### PR TITLE
import grouping/ordering consistency

### DIFF
--- a/newrelic.js
+++ b/newrelic.js
@@ -1,9 +1,10 @@
-/**
+/*
  * New Relic agent configuration.
  *
  * See lib/config.defaults.js in the agent distribution for a more complete
  * description of configuration variables and their potential values.
- */
+*/
+
 const cfenv = require('cfenv')
 
 const env = cfenv.getAppEnv()

--- a/src/actions/composite.js
+++ b/src/actions/composite.js
@@ -6,6 +6,7 @@ import { fetchUcrParticipation } from '../actions/ucr'
 import history, { createNewLocation } from '../util/history'
 import { shouldFetchUcr, shouldFetchSummaries, shouldFetchNibrs } from '../util/ucr'
 
+
 const fetchData = () => (dispatch, getState) => {
   const { filters } = getState()
 

--- a/src/actions/filters.js
+++ b/src/actions/filters.js
@@ -1,6 +1,7 @@
 import { FILTER_RESET, FILTERS_UPDATE } from './constants'
-import lookupUsa from '../util/usa'
 import offenses from '../util/offenses'
+import lookupUsa from '../util/usa'
+
 
 const isValidCrime = crime => offenses.includes(crime)
 const isValidPlace = place => lookupUsa(place)

--- a/src/actions/glossary.js
+++ b/src/actions/glossary.js
@@ -4,6 +4,7 @@ import {
   GLOSSARY_SHOW_TERM,
 } from './constants'
 
+
 export const hideGlossary = () => ({
   type: GLOSSARY_HIDE,
 })

--- a/src/actions/nibrs.js
+++ b/src/actions/nibrs.js
@@ -5,6 +5,7 @@ import {
 } from './constants'
 import api from '../util/api'
 
+
 export const fetchingNibrs = () => ({
   type: NIBRS_FETCHING,
 })

--- a/src/actions/sidebar.js
+++ b/src/actions/sidebar.js
@@ -1,4 +1,5 @@
 import { SIDEBAR_HIDE, SIDEBAR_SHOW } from './constants'
 
+
 export const hideSidebar = () => ({ type: SIDEBAR_HIDE })
 export const showSidebar = () => ({ type: SIDEBAR_SHOW })

--- a/src/actions/summary.js
+++ b/src/actions/summary.js
@@ -4,6 +4,7 @@ import {
 } from './constants'
 import api from '../util/api'
 
+
 export const fetchingSummary = () => ({
   type: SUMMARY_FETCHING,
 })

--- a/src/actions/ucr.js
+++ b/src/actions/ucr.js
@@ -4,6 +4,7 @@ import {
 } from './constants'
 import api from '../util/api'
 
+
 export const fetchingUcrParticipation = () => ({
   type: UCR_PARTICIPATION_FETCHING,
 })

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -1,11 +1,10 @@
-/* eslint-disable max-len */
-
 import React from 'react'
 
 import UsaMap from './UsaMap'
 
 import ucr from '../util/ucr'
 import usa, { data as usaData } from '../util/usa'
+
 
 const colorFromUcr = info => {
   if (info.srs && !info.nibrs) return 'fill-blue-lighter'
@@ -192,7 +191,8 @@ const About = () => (
           <div className='sm-col sm-col-4 px2 mb4 sm-mb0'>
             <h3 className='mt0 mb2 fs-22 sans-serif red'>Technical issues?</h3>
             <p className='m0'>
-              Please submit technical questions about the application and the API via <a href='https://github.com/18F/crime-data-explorer'>GitHub</a>
+              Please submit technical questions about the application and the API
+              via <a href='https://github.com/18F/crime-data-explorer'>GitHub</a>
             </p>
           </div>
           <div className='sm-col sm-col-4 px2 mb4 sm-mb0'>

--- a/src/components/AboutTheData.js
+++ b/src/components/AboutTheData.js
@@ -3,6 +3,7 @@ import React from 'react'
 
 import content from '../util/content'
 
+
 const markdown = md()
 
 const AboutTheData = ({ crime }) => {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -9,6 +9,7 @@ import Footer from './Footer'
 import Glossary from './Glossary'
 import Header from './Header'
 
+
 const App = ({ appState, children, dispatch, location }) => (
   <div className='site'>
     <Disclaimer />

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -5,6 +5,7 @@ import React from 'react'
 import XAxis from './XAxis'
 import YAxis from './YAxis'
 
+
 const BarChart = ({
   size = { width: 600, height: 400 },
   margin = { top: 20, right: 20, bottom: 30, left: 50 },

--- a/src/components/BetaBanner.js
+++ b/src/components/BetaBanner.js
@@ -2,6 +2,7 @@
 
 import React from 'react'
 
+
 const BetaBanner = () => (
   <div className='md-absolute top-0 right-0 fs-10 md-fs-16 center'>
     <div className='md-mr2 p1 md-py2 md-pl3 md-pr4 md-inline-block md-rounded-bottom bg-red white'>

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -1,6 +1,7 @@
-import { Link } from 'react-router'
-import React from 'react'
 import startCase from 'lodash.startcase'
+import React from 'react'
+import { Link } from 'react-router'
+
 
 const Breadcrumbs = ({ crime, place }) => {
   const links = [

--- a/src/components/CrimeTypeFilter.js
+++ b/src/components/CrimeTypeFilter.js
@@ -1,8 +1,9 @@
-import { Link } from 'react-router'
 import React from 'react'
+import { Link } from 'react-router'
 
 import FilterGroup from './FilterGroup'
 import { crimeTypes } from '../util/data'
+
 
 const { violentCrime, propertyCrime } = crimeTypes
 

--- a/src/components/Disclaimer.js
+++ b/src/components/Disclaimer.js
@@ -1,5 +1,6 @@
 import React from 'react'
 
+
 const Disclaimer = () => (
   <div className='clearfix p1 fs-10 sm-fs-12 line-height-1 bg-white'>
     <img

--- a/src/components/DownloadBulkNibrs.js
+++ b/src/components/DownloadBulkNibrs.js
@@ -1,9 +1,10 @@
 import range from 'lodash.range'
-import React from 'react'
 import startCase from 'lodash.startcase'
+import React from 'react'
 
 import Term from './Term'
 import ucrProgram from '../../data/ucr-program-participation.json'
+
 
 /* these codes are repeated here (seemingly also in util/api.js) because
    different codes are needed for different parts of the application

--- a/src/components/DownloadDataBtn.js
+++ b/src/components/DownloadDataBtn.js
@@ -3,6 +3,7 @@ import React from 'react'
 import jsonToCsv from '../util/csv'
 import { slugify } from '../util/text'
 
+
 const downloadData = (fname, data) => {
   const file = `${slugify(fname)}.csv`
   const dataStr = jsonToCsv(data)

--- a/src/components/DownloadsAndDocs.js
+++ b/src/components/DownloadsAndDocs.js
@@ -2,8 +2,9 @@ import React from 'react'
 
 import DownloadBulkNibrs from './DownloadBulkNibrs'
 import DownloadDataBtn from './DownloadDataBtn'
-import otherDatasets from '../../content/datasets.yml'
 import Term from './Term'
+import otherDatasets from '../../content/datasets.yml'
+
 
 const border = 'border-bottom border-blue-lighter'
 

--- a/src/components/ErrorCard.js
+++ b/src/components/ErrorCard.js
@@ -1,5 +1,6 @@
 import React from 'react'
 
+
 const ErrorCard = ({ error }) => (
   <div className='p4 bg-white'>
     <p className='fs-18'>🙁 Data fetching error:</p>

--- a/src/components/Explorer.js
+++ b/src/components/Explorer.js
@@ -7,12 +7,12 @@ import NotFound from './NotFound'
 import Sidebar from './Sidebar'
 import TrendContainer from './TrendContainer'
 import UcrParticipationInformation from './UcrParticipationInformation'
-
-import { hideSidebar, showSidebar } from '../actions/sidebar'
 import { updateApp } from '../actions/composite'
-import lookup from '../util/usa'
+import { hideSidebar, showSidebar } from '../actions/sidebar'
 import offenses from '../util/offenses'
 import ucrParticipation from '../util/ucr'
+import lookup from '../util/usa'
+
 
 const filterNibrsData = (data, { since, until }) => {
   if (!data) return false

--- a/src/components/FilterGroup.js
+++ b/src/components/FilterGroup.js
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { slugify } from '../util/text'
 
+
 const FilterGroup = ({ name, options, onChange, selected, title }) => {
   const handleChange = e => onChange({ crime: e.target.value })
 

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -2,6 +2,7 @@ import React from 'react'
 
 import Link from './Link'
 
+
 const links = [
   {
     text: 'Home',

--- a/src/components/Glossary.js
+++ b/src/components/Glossary.js
@@ -4,6 +4,7 @@ import React from 'react'
 import { hideGlossary, showGlossary } from '../actions/glossary'
 import terms from '../../data/terms.json'
 
+
 let GlossaryPanel
 if (typeof window !== 'undefined') GlossaryPanel = require('glossary-panel')
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router'
 
 import { nationalKey } from '../util/usa'
 
+
 const isHome = loc => loc.pathname === '/'
 const isExplorer = loc => loc.pathname.includes('explorer')
 

--- a/src/components/Hint.js
+++ b/src/components/Hint.js
@@ -1,5 +1,6 @@
 import React from 'react'
 
+
 const Hint = ({ value, position }) => {
   const width = String(value).length * 10
   const style = {

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -5,12 +5,12 @@ import { Link } from 'react-router'
 import LocationSelect from './LocationSelect'
 import Term from './Term'
 import UsaMap from './UsaMap'
-
-import { slugify } from '../util/text'
-import stateLookup from '../util/usa'
 import { updateApp } from '../actions/composite'
 import { updateFilters } from '../actions/filters'
+import { slugify } from '../util/text'
+import stateLookup from '../util/usa'
 import otherDataSets from '../../content/datasets.yml'
+
 
 const Home = ({ appState, dispatch, location }) => {
   const { crime, place } = appState.filters

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Link as RouterLink } from 'react-router'
 
+
 const Link = props => {
   const { to } = props
   let el = (<RouterLink {...props}>{props.children}</RouterLink>)

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -1,5 +1,6 @@
 import React from 'react'
 
+
 const Loading = ({ text }) => (
   <div className='mt3 mb8 fs-14 caps center'>
     <img

--- a/src/components/LocationFilter.js
+++ b/src/components/LocationFilter.js
@@ -3,6 +3,7 @@ import React from 'react'
 import LocationSelect from './LocationSelect'
 import PlaceThumbnail from './PlaceThumbnail'
 
+
 const LocationFilter = ({ onChange, selected }) => (
   <div id='location' className='mb4'>
     <div className='mb3 fs-22 bold border-bottom'>Location</div>

--- a/src/components/LocationSelect.js
+++ b/src/components/LocationSelect.js
@@ -1,10 +1,12 @@
 /* eslint no-console: 0 */
-import { entries } from 'd3-collection'
-import React from 'react'
-import startCase from 'lodash.startcase'
 
-import { data } from '../util/usa'
+import { entries } from 'd3-collection'
+import startCase from 'lodash.startcase'
+import React from 'react'
+
 import { slugify } from '../util/text'
+import { data } from '../util/usa'
+
 
 const places = entries(data).map(d => startCase(d.value))
 

--- a/src/components/NibrsCard.js
+++ b/src/components/NibrsCard.js
@@ -7,6 +7,7 @@ import NibrsHistogram from './NibrsHistogram'
 import NibrsTable from './NibrsTable'
 import { slugify } from '../util/text'
 
+
 const NibrsCard = ({ crime, data, place, since, title, until }) => {
   const charts = data.map((d, i) => {
     const props = { key: i, ...d }

--- a/src/components/NibrsContainer.js
+++ b/src/components/NibrsContainer.js
@@ -1,6 +1,6 @@
 import { format } from 'd3-format'
-import React from 'react'
 import startCase from 'lodash.startcase'
+import React from 'react'
 
 import ErrorCard from './ErrorCard'
 import Loading from './Loading'
@@ -8,6 +8,7 @@ import NibrsCard from './NibrsCard'
 import parseNibrs from '../util/nibrs'
 import Term from './Term'
 import ucrParticipation from '../util/ucr'
+
 
 const fbiLink = 'https://ucr.fbi.gov/ucr-program-data-collections'
 const formatNumber = format(',')

--- a/src/components/NibrsDonut.js
+++ b/src/components/NibrsDonut.js
@@ -5,6 +5,7 @@ import React from 'react'
 
 import NibrsDonutDetails from './NibrsDonutDetails'
 
+
 class NibrsDonut extends React.Component {
   constructor(props) {
     super(props)

--- a/src/components/NibrsDonutDetails.js
+++ b/src/components/NibrsDonutDetails.js
@@ -1,6 +1,7 @@
 import { format } from 'd3-format'
 import React from 'react'
 
+
 const fmt = format(',.0f')
 
 const NibrsDonutDetails = ({ colorMap, data, hover, onMouseOver, onMouseOut, selected }) => (

--- a/src/components/NibrsHistogram.js
+++ b/src/components/NibrsHistogram.js
@@ -5,6 +5,7 @@ import React from 'react'
 import NibrsHistogramDetails from './NibrsHistogramDetails'
 import XAxis from './XAxis'
 
+
 class NibrsHistogram extends React.Component {
   constructor(props) {
     super(props)

--- a/src/components/NibrsHistogramDetails.js
+++ b/src/components/NibrsHistogramDetails.js
@@ -2,6 +2,7 @@ import { format } from 'd3-format'
 import pluralize from 'pluralize'
 import React from 'react'
 
+
 const fmt = format(',.0f')
 
 const NibrsHistogramDetails = ({ data, noun }) => {

--- a/src/components/NibrsTable.js
+++ b/src/components/NibrsTable.js
@@ -2,6 +2,7 @@ import { format } from 'd3-format'
 import pluralize from 'pluralize'
 import React from 'react'
 
+
 const formatNumber = format(',')
 const formatPercent = p => (p > 0.01 ? format('.0%')(p) : '<1%')
 const formatSI = n => (Number(n) > 10 ? format('.2s')(n) : formatNumber(n))

--- a/src/components/NoData.js
+++ b/src/components/NoData.js
@@ -1,5 +1,6 @@
 import React from 'react'
 
+
 const NoData = () => (
   <div className='p4 bg-white'>
     <div className='fs-18'>🙁 There’s no data at this time.</div>

--- a/src/components/NotFound.js
+++ b/src/components/NotFound.js
@@ -1,5 +1,6 @@
 import React from 'react'
 
+
 const NotFound = () => (
   <div className='mb8 px2 py8 center'>
     <h1 className='mt0 mb1 fs-40 monospace'>404</h1>

--- a/src/components/PlaceThumbnail.js
+++ b/src/components/PlaceThumbnail.js
@@ -3,6 +3,7 @@ import { geoAlbersUsa, geoPath } from 'd3-geo'
 import React from 'react'
 import { feature, mesh } from 'topojson'
 
+
 const Container = ({ children }) => (
   <div className='my4 center'>
     <div className='aspect-ratio aspect-ratio--4x3'>{children}</div>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,11 +1,11 @@
-import React from 'react'
 import startCase from 'lodash.startcase'
+import React from 'react'
 
 import CrimeTypeFilter from './CrimeTypeFilter'
 import LocationFilter from './LocationFilter'
 import TimePeriodFilter from './TimePeriodFilter'
-
 import { hideSidebar } from '../actions/sidebar'
+
 
 const Sidebar = ({ dispatch, filters, isOpen, onChange, router }) => {
   const { crime, place } = router.params

--- a/src/components/Term.js
+++ b/src/components/Term.js
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { showTerm } from '../actions/glossary'
 
+
 const Term = ({ children, dispatch, id }) => {
   const handler = e => {
     e.preventDefault()

--- a/src/components/TimePeriodFilter.js
+++ b/src/components/TimePeriodFilter.js
@@ -1,6 +1,7 @@
 import range from 'lodash.range'
 import React from 'react'
 
+
 const MIN_YEAR = 1960
 const MAX_YEAR = 2014
 const YEAR_RANGE = range(MIN_YEAR, MAX_YEAR + 1)

--- a/src/components/TrendChart.js
+++ b/src/components/TrendChart.js
@@ -3,17 +3,17 @@
 import { bisector, extent, max, min } from 'd3-array'
 import { scaleLinear, scaleOrdinal, scaleTime } from 'd3-scale'
 import { line } from 'd3-shape'
+import { timeParse } from 'd3-time-format'
 import startCase from 'lodash.startcase'
 import throttle from 'lodash.throttle'
-import { timeParse } from 'd3-time-format'
 import React from 'react'
 
 import DownloadDataBtn from './DownloadDataBtn'
 import TrendChartDetails from './TrendChartDetails'
 import XAxis from './XAxis'
 import YAxis from './YAxis'
-
 import { slugify } from '../util/text'
+
 
 class TrendChart extends React.Component {
   constructor(props) {

--- a/src/components/TrendChartDetails.js
+++ b/src/components/TrendChartDetails.js
@@ -2,9 +2,10 @@ import { format } from 'd3-format'
 import lowerCase from 'lodash.lowercase'
 import React from 'react'
 
+import Term from './Term'
 import mapCrimeToGlossaryTerm from '../util/glossary'
 import { nationalKey } from '../util/usa'
-import Term from './Term'
+
 
 const formatRate = format('.1f')
 const formatTotal = format(',.0f')

--- a/src/components/TrendContainer.js
+++ b/src/components/TrendContainer.js
@@ -1,10 +1,11 @@
-import React from 'react'
 import startCase from 'lodash.startcase'
+import React from 'react'
 
 import Loading from './Loading'
 import NoData from './NoData'
 import TrendChart from './TrendChart'
 import TrendSourceText from './TrendSourceText'
+
 
 const TrendContainer = ({ crime, place, filters, data, dispatch, loading, keys }) => {
   const { since, until } = filters

--- a/src/components/TrendSourceText.js
+++ b/src/components/TrendSourceText.js
@@ -1,8 +1,9 @@
-import React from 'react'
 import startCase from 'lodash.startcase'
+import React from 'react'
 
 import Term from './Term'
 import ucrParticipation from '../util/ucr'
+
 
 const TrendSourceText = ({ dispatch, place, since, until }) => {
   const ucr = ucrParticipation(place)

--- a/src/components/UcrParticipationInformation.js
+++ b/src/components/UcrParticipationInformation.js
@@ -1,11 +1,12 @@
 import { format } from 'd3-format'
-import React from 'react'
 import startCase from 'lodash.startcase'
+import React from 'react'
 
-import content from '../util/content'
 import Term from './Term'
+import content from '../util/content'
 import ucrParticipation from '../util/ucr'
 import lookupUsa, { nationalKey } from '../util/usa'
+
 
 const formatNumber = format(',')
 

--- a/src/components/UsaMap.js
+++ b/src/components/UsaMap.js
@@ -1,10 +1,10 @@
-import React from 'react'
 import startCase from 'lodash.startcase'
+import React from 'react'
 
 import Hint from './Hint'
-
 import stateLookup from '../util/usa'
 import svgData from '../../data/usa-state-svg.json'
+
 
 class UsaMap extends React.Component {
   constructor(props) {

--- a/src/components/XAxis.js
+++ b/src/components/XAxis.js
@@ -1,5 +1,6 @@
 import React from 'react'
 
+
 const XAxis = ({
   tickCt = 8,
   tickSizeOuter = 6,

--- a/src/components/YAxis.js
+++ b/src/components/YAxis.js
@@ -1,6 +1,7 @@
 import { format } from 'd3-format'
 import React from 'react'
 
+
 const getTickVals = (domain, ticks) => {
   const [s, e] = domain
   const step = ((e - s) * 1.0) / (ticks - 1)

--- a/src/html.js
+++ b/src/html.js
@@ -2,26 +2,25 @@
 
 import sharingMetaTags from './util/sharing'
 
-export default function renderHtml(content, state) {
-  return `
-    <!DOCTYPE html>
-    <html lang='en'>
-      <head>
-        <meta charset='utf-8'>
-        <meta name='viewport' content='width=device-width, initial-scale=1'>
-        ${sharingMetaTags(state)}
-        <title>Crime Data Explorer</title>
-        <link href='/app.css' rel='stylesheet'>
-      </head>
-      <body>
-        <div id='app'>${content}</div>
-        <script>
-          window.__STATE__ = ${JSON.stringify(state).replace(/</g, '\\u003c')}
-        </script>
-        <script src='/bundle.js'></script>
-        <script>!function(a,b,c,d,e,f,g){a.GoogleAnalyticsObject=e,a[e]=a[e]||function(){(a[e].q=a[e].q||[]).push(arguments)},a[e].l=1*new Date,f=b.createElement(c),g=b.getElementsByTagName(c)[0],f.async=1,f.src=d,g.parentNode.insertBefore(f,g)}(window,document,"script","https://www.google-analytics.com/analytics.js","ga"),ga("create","UA-48605964-47","auto"),ga("set","anonymizeIp",!0),ga("set","forceSSL",!0),ga("send","pageview");</script>
-        <script src='https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js' id='_fed_an_ua_tag'></script>
-      </body>
-    </html>
-  `
-}
+
+export default (content, state) => (`
+  <!DOCTYPE html>
+  <html lang='en'>
+    <head>
+      <meta charset='utf-8'>
+      <meta name='viewport' content='width=device-width, initial-scale=1'>
+      ${sharingMetaTags(state)}
+      <title>Crime Data Explorer</title>
+      <link href='/app.css' rel='stylesheet'>
+    </head>
+    <body>
+      <div id='app'>${content}</div>
+      <script>
+        window.__STATE__ = ${JSON.stringify(state).replace(/</g, '\\u003c')}
+      </script>
+      <script src='/bundle.js'></script>
+      <script>!function(a,b,c,d,e,f,g){a.GoogleAnalyticsObject=e,a[e]=a[e]||function(){(a[e].q=a[e].q||[]).push(arguments)},a[e].l=1*new Date,f=b.createElement(c),g=b.getElementsByTagName(c)[0],f.async=1,f.src=d,g.parentNode.insertBefore(f,g)}(window,document,"script","https://www.google-analytics.com/analytics.js","ga"),ga("create","UA-48605964-47","auto"),ga("set","anonymizeIp",!0),ga("set","forceSSL",!0),ga("send","pageview");</script>
+      <script src='https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js' id='_fed_an_ua_tag'></script>
+    </body>
+  </html>
+`)

--- a/src/reducers/filters.js
+++ b/src/reducers/filters.js
@@ -4,6 +4,7 @@ import {
   FILTERS_UPDATE,
 } from '../actions/constants'
 
+
 const initialState = {
   since: 2004,
   until: 2014,

--- a/src/reducers/glossary.js
+++ b/src/reducers/glossary.js
@@ -4,6 +4,7 @@ import {
   GLOSSARY_SHOW_TERM,
 } from '../actions/constants'
 
+
 const initialState = {
   isOpen: false,
   term: null,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -8,6 +8,7 @@ import sidebar from './sidebar'
 import summaries from './summary'
 import ucr from './ucr'
 
+
 export default combineReducers({
   filters,
   glossary,

--- a/src/reducers/nibrs.js
+++ b/src/reducers/nibrs.js
@@ -4,6 +4,7 @@ import {
   NIBRS_RECEIVED,
 } from '../actions/constants'
 
+
 const initialState = {
   loading: false,
   data: null,

--- a/src/reducers/sidebar.js
+++ b/src/reducers/sidebar.js
@@ -1,5 +1,6 @@
 import { SIDEBAR_HIDE, SIDEBAR_SHOW } from '../actions/constants'
 
+
 const initialState = { isOpen: false }
 
 export default (state = initialState, action) => {

--- a/src/reducers/summary.js
+++ b/src/reducers/summary.js
@@ -3,6 +3,7 @@ import {
   SUMMARY_RECEIVED,
 } from '../actions/constants'
 
+
 const initialState = {
   loading: false,
   data: {},

--- a/src/reducers/ucr.js
+++ b/src/reducers/ucr.js
@@ -3,6 +3,7 @@ import {
   UCR_PARTICIPATION_RECEIVED,
 } from '../actions/constants'
 
+
 const initialState = {
   loading: false,
   data: {},

--- a/src/routes.js
+++ b/src/routes.js
@@ -5,9 +5,10 @@ import About from './components/About'
 import App from './components/App'
 import DownloadsAndDocs from './components/DownloadsAndDocs'
 import Explorer from './components/Explorer'
-import history from './util/history'
 import Home from './components/Home'
 import NotFound from './components/NotFound'
+import history from './util/history'
+
 
 const scrollToTop = () => window.scroll(0, 0)
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,26 +1,24 @@
-/* eslint-disable comma-dangle, global-require, import/first, no-console, padded-blocks */
+/* eslint-disable global-require, no-console, padded-blocks */
 
 import 'babel-polyfill'
 
-import path from 'path'
-
+import http from 'axios'
 import cfenv from 'cfenv'
 import express from 'express'
-import http from 'axios'
+import path from 'path'
 import React from 'react'
 import { renderToString } from 'react-dom/server'
 import { Provider } from 'react-redux'
 import { match, RouterContext } from 'react-router'
 
-import { updateFilters } from './actions/filters'
-import configureStore from './store'
-import history from './util/history'
 import renderHtml from './html'
 import routes from './routes'
+import configureStore from './store'
+import { updateFilters } from './actions/filters'
+import history from './util/history'
 
-if (process.env.NODE_ENV === 'production') {
-  require('newrelic')
-}
+if (process.env.NODE_ENV === 'production') require('newrelic')
+
 
 const env = cfenv.getAppEnv()
 const credService = env.getService('crime-data-api-creds') || { credentials: {} }

--- a/src/store.js
+++ b/src/store.js
@@ -6,6 +6,7 @@ import thunk from 'redux-thunk'
 
 import reducer from './reducers'
 
+
 const middlewares = [thunk]
 if (process.env.NODE_ENV !== 'production') middlewares.push(createLogger())
 

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -1,9 +1,10 @@
 import upperFirst from 'lodash.upperfirst'
 
 import { get } from './http'
-import lookupUsa, { nationalKey } from './usa'
 import { mapToApiOffense, mapToApiOffenseParam } from './offenses'
 import { slugify } from './text'
+import lookupUsa, { nationalKey } from './usa'
+
 
 const API = '/api'
 

--- a/src/util/content.js
+++ b/src/util/content.js
@@ -13,6 +13,7 @@ import robberyContent from '../../content/crimes/robbery.yml'
 import stateContent from '../../content/locations/states.yml'
 import violentCrimeContent from '../../content/crimes/violent-crime.yml'
 
+
 const content = {
   ...stateContent,
   crimes: {

--- a/src/util/csv.js
+++ b/src/util/csv.js
@@ -1,5 +1,6 @@
 import flatten from 'lodash.flatten'
 
+
 const flattenCols = data => {
   const firstRow = data[0]
   const colsToFlatten = Object.keys(firstRow).map(key => {

--- a/src/util/history.js
+++ b/src/util/history.js
@@ -1,6 +1,5 @@
 import { browserHistory } from 'react-router'
 
-export default browserHistory
 
 const splitPath = path => {
   const split = path.split('/')
@@ -35,3 +34,5 @@ export const createNewLocation = ({ change, location }) => {
     pathname,
   }
 }
+
+export default browserHistory

--- a/src/util/http.js
+++ b/src/util/http.js
@@ -2,8 +2,9 @@ import http from 'axios'
 import flatten from 'lodash.flatten'
 import range from 'lodash.range'
 
-import createUrl from './url'
 import storage from './localStorage'
+import createUrl from './url'
+
 
 const get = (url, params = {}) => {
   const key = createUrl(url, params)

--- a/src/util/localStorage.js
+++ b/src/util/localStorage.js
@@ -1,4 +1,3 @@
-
 const getItem = key => {
   if (!window || !window.localStorage) return Promise.resolve(null)
 

--- a/src/util/offenses.js
+++ b/src/util/offenses.js
@@ -1,5 +1,6 @@
 import { slugify } from './text'
 
+
 const offenses = {
   'aggravated-assault': 'aggravated-assault',
   arson: 'arson',
@@ -30,8 +31,4 @@ const offenseParams = {
 const mapToApiOffense = o => offenses[o] || slugify(o)
 const mapToApiOffenseParam = o => offenseParams[o]
 
-export default ids
-export {
-  mapToApiOffense,
-  mapToApiOffenseParam,
-}
+export { ids as default, mapToApiOffense, mapToApiOffenseParam }

--- a/src/util/sharing.js
+++ b/src/util/sharing.js
@@ -1,10 +1,11 @@
 /* eslint-disable max-len */
 
-import pluralize from 'pluralize'
 import startCase from 'lodash.startcase'
+import pluralize from 'pluralize'
 
 import offenses from './offenses'
 import usa from './usa'
+
 
 const basicTitle = 'The Crime Data Explorer publishes nation-wide crime data collected by the FBI in a digital format. The tool allows you to view trends and download bulk data allowing you to get a better understanding of crime across the country.'
 
@@ -21,12 +22,10 @@ const openGraphTags = state => {
   return `<meta property="og:title" content="${title}" />`
 }
 
-const twitterCardTags = () => (
-  `
+const twitterCardTags = () => (`
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@fbi" />
-  `.trim()
-)
+`.trim())
 
 export default function createSharingMetaTagsFromState(state) {
   return `${openGraphTags(state)}\n${twitterCardTags(state)}`

--- a/src/util/ucr.js
+++ b/src/util/ucr.js
@@ -1,7 +1,9 @@
-import data from '../../data/ucr-program-participation.json'
-import lookupUsa from './usa'
 import offenses from './offenses'
 import { slugify } from './text'
+import lookupUsa from './usa'
+
+import data from '../../data/ucr-program-participation.json'
+
 
 const lookup = state => data[slugify(state)]
 

--- a/src/util/usa.js
+++ b/src/util/usa.js
@@ -2,6 +2,7 @@ import lowerCase from 'lodash.lowercase'
 
 import { slugify } from '../util/text'
 
+
 const data = {
   usa: 'united states',
   ak: 'alaska',

--- a/test/actions/composite.test.js
+++ b/test/actions/composite.test.js
@@ -2,10 +2,10 @@
 
 import sinon from 'sinon'
 
-
-import * as historyUtil from '../../src/util/history'
-import * as filterActions from '../../src/actions/filters'
 import { updateApp } from '../../src/actions/composite'
+import * as filterActions from '../../src/actions/filters'
+import * as historyUtil from '../../src/util/history'
+
 
 const noop = () => {}
 

--- a/test/actions/filters.test.js
+++ b/test/actions/filters.test.js
@@ -4,8 +4,8 @@ import {
   FILTER_RESET,
   FILTERS_UPDATE,
 } from '../../src/actions/constants'
-
 import { resetFilter, updateFilters } from '../../src/actions/filters'
+
 
 describe('filters actions', () => {
   describe('resetFilter()', () => {

--- a/test/actions/glossary.test.js
+++ b/test/actions/glossary.test.js
@@ -5,8 +5,8 @@ import {
   GLOSSARY_SHOW,
   GLOSSARY_SHOW_TERM,
 } from '../../src/actions/constants'
-
 import { hideGlossary, showGlossary, showTerm } from '../../src/actions/glossary'
+
 
 describe('glossary actions', () => {
   describe('hideGlossary()', () => {

--- a/test/actions/nibrs.test.js
+++ b/test/actions/nibrs.test.js
@@ -7,15 +7,14 @@ import {
   NIBRS_FETCHING,
   NIBRS_RECEIVED,
 } from '../../src/actions/constants'
-
 import {
   failedNibrs,
   fetchNibrs,
   fetchingNibrs,
   receivedNibrs,
 } from '../../src/actions/nibrs'
-
 import api from '../../src/util/api'
+
 
 const createPromise = (res, err) => {
   if (!err) return Promise.resolve(res)

--- a/test/actions/sidebar.test.js
+++ b/test/actions/sidebar.test.js
@@ -3,6 +3,7 @@
 import { SIDEBAR_HIDE, SIDEBAR_SHOW } from '../../src/actions/constants'
 import { hideSidebar, showSidebar } from '../../src/actions/sidebar'
 
+
 describe('sidebar actions', () => {
   describe('hideSidebar()', () => {
     it('should return a SIDEBAR_HIDE action', () => {

--- a/test/actions/summary.test.js
+++ b/test/actions/summary.test.js
@@ -6,15 +6,14 @@ import {
   SUMMARY_FETCHING,
   SUMMARY_RECEIVED,
 } from '../../src/actions/constants'
-
 import {
   fetchSummaries,
   fetchingSummary,
   receivedSummary,
 } from '../../src/actions/summary'
-
-import { nationalKey } from '../../src/util/usa'
 import api from '../../src/util/api'
+import { nationalKey } from '../../src/util/usa'
+
 
 const createPromise = (res, err) => {
   if (!err) return Promise.resolve(res)

--- a/test/actions/ucr.test.js
+++ b/test/actions/ucr.test.js
@@ -6,14 +6,13 @@ import {
   UCR_PARTICIPATION_FETCHING,
   UCR_PARTICIPATION_RECEIVED,
 } from '../../src/actions/constants'
-
 import {
   fetchingUcrParticipation,
   receivedUcrParticipation,
   fetchUcrParticipation,
 } from '../../src/actions/ucr'
-
 import api from '../../src/util/api'
+
 
 const createPromise = (res, err) => {
   if (!err) return Promise.resolve(res)

--- a/test/components/BarChart.test.js
+++ b/test/components/BarChart.test.js
@@ -1,9 +1,10 @@
 /* eslint no-undef: 0 */
 
-import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow } from 'enzyme'
+import React from 'react'
 
-import BarChart from '../../src/components/BarChart';
+import BarChart from '../../src/components/BarChart'
+
 
 describe('BarChart', () => {
   const data = [['red', 5], ['green', 7], ['yellow', 2]]

--- a/test/components/FilterGroup.test.js
+++ b/test/components/FilterGroup.test.js
@@ -1,9 +1,10 @@
 /* eslint no-undef: 0 */
 
-import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow } from 'enzyme'
+import React from 'react'
 
-import FilterGroup from '../../src/components/FilterGroup';
+import FilterGroup from '../../src/components/FilterGroup'
+
 
 describe('FilterGroup', () => {
   const title = 'FilterGroup'

--- a/test/components/NibrsTable.test.js
+++ b/test/components/NibrsTable.test.js
@@ -1,7 +1,8 @@
-import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow } from 'enzyme'
+import React from 'react'
 
-import NibrsTable from '../../src/components/NibrsTable';
+import NibrsTable from '../../src/components/NibrsTable'
+
 
 describe('NibrsTable', () => {
   const data = n => [...Array(n)].map((_, i) => ({ key: i, count: 10 }))

--- a/test/components/TrendChart.test.js
+++ b/test/components/TrendChart.test.js
@@ -1,9 +1,10 @@
 /* eslint no-undef: 0 */
 
-import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow } from 'enzyme'
+import React from 'react'
 
-import TrendChart from '../../src/components/TrendChart';
+import TrendChart from '../../src/components/TrendChart'
+
 
 describe('TrendChart', () => {
   const data = [

--- a/test/reducers/filters.test.js
+++ b/test/reducers/filters.test.js
@@ -4,8 +4,8 @@ import {
   FILTER_RESET,
   FILTERS_UPDATE,
 } from '../../src/actions/constants'
-
 import reducer from '../../src/reducers/filters'
+
 
 describe('filters', () => {
   describe('initial state', () => {

--- a/test/reducers/glossary.test.js
+++ b/test/reducers/glossary.test.js
@@ -5,8 +5,8 @@ import {
   GLOSSARY_SHOW,
   GLOSSARY_SHOW_TERM,
 } from '../../src/actions/constants'
-
 import reducer from '../../src/reducers/glossary'
+
 
 describe('glossary', () => {
   it('it should return the initial state', () => {

--- a/test/reducers/nibrs.test.js
+++ b/test/reducers/nibrs.test.js
@@ -5,8 +5,8 @@ import {
   NIBRS_FETCHING,
   NIBRS_RECEIVED,
 } from '../../src/actions/constants'
-
 import reducer from '../../src/reducers/nibrs'
+
 
 describe('nibrs', () => {
   describe('initial state', () => {

--- a/test/reducers/sidebar.test.js
+++ b/test/reducers/sidebar.test.js
@@ -4,8 +4,8 @@ import {
   SIDEBAR_HIDE,
   SIDEBAR_SHOW,
 } from '../../src/actions/constants'
-
 import reducer from '../../src/reducers/sidebar'
+
 
 describe('sidebar', () => {
   it('it should return the initial state', () => {

--- a/test/reducers/summary.test.js
+++ b/test/reducers/summary.test.js
@@ -4,8 +4,8 @@ import {
   SUMMARY_FETCHING,
   SUMMARY_RECEIVED,
 } from '../../src/actions/constants'
-
 import reducer from '../../src/reducers/summary'
+
 
 describe('summary', () => {
   describe('initial state', () => {

--- a/test/reducers/ucr.test.js
+++ b/test/reducers/ucr.test.js
@@ -4,8 +4,8 @@ import {
   UCR_PARTICIPATION_FETCHING,
   UCR_PARTICIPATION_RECEIVED,
 } from '../../src/actions/constants'
-
 import reducer from '../../src/reducers/ucr'
+
 
 describe('ucr', () => {
   describe('initial state', () => {

--- a/test/util/api.test.js
+++ b/test/util/api.test.js
@@ -2,8 +2,8 @@
 
 import sinon from 'sinon'
 
-import * as http from '../../src/util/http'
 import api from '../../src/util/api'
+import * as http from '../../src/util/http'
 
 
 const createPromise = (res, err) => {

--- a/test/util/csv.test.js
+++ b/test/util/csv.test.js
@@ -2,6 +2,7 @@
 
 import jsonToCsv from '../../src/util/csv'
 
+
 const simpleJson = [
   { simpleKey: 'value1A', secondKey: 'value1B' },
   { simpleKey: 'value2A', secondKey: 'value2B' },

--- a/test/util/glossary.test.js
+++ b/test/util/glossary.test.js
@@ -2,6 +2,7 @@
 
 import mapCrimeToGlossaryTerm from '../../src/util/glossary'
 
+
 describe('glossary utility', () => {
   it('default export should be a function', () => {
     expect(typeof mapCrimeToGlossaryTerm).toEqual('function')

--- a/test/util/history.test.js
+++ b/test/util/history.test.js
@@ -2,6 +2,7 @@
 
 import history, { createNewLocation } from '../../src/util/history'
 
+
 describe('history utility', () => {
   it('should export a react-router history singleton', () => {
     expect(typeof history.createHref).toEqual('function')

--- a/test/util/http.test.js
+++ b/test/util/http.test.js
@@ -6,6 +6,7 @@ import sinon from 'sinon'
 import * as http from '../../src/util/http'
 import storage from '../../src/util/localStorage'
 
+
 const createPromise = (res, err) => {
   if (!err) return Promise.resolve(res)
   return Promise.reject(err);

--- a/test/util/localStorage.test.js
+++ b/test/util/localStorage.test.js
@@ -2,6 +2,7 @@
 
 import storage from '../../src/util/localStorage'
 
+
 const createStorageMock = () => {
   const store = {}
 

--- a/test/util/nibrs.test.js
+++ b/test/util/nibrs.test.js
@@ -1,8 +1,8 @@
 /* eslint no-undef: 0 */
 
+import mockApiData from '../fixtures/nibrsApiResponse.json'
 import parseNibrs, { reshape, rename } from '../../src/util/nibrs'
 
-import mockApiData from '../fixtures/nibrsApiResponse.json'
 
 describe('nibrs utility', () => {
   describe('reshape()', () => {

--- a/test/util/offenses.test.js
+++ b/test/util/offenses.test.js
@@ -2,6 +2,7 @@
 
 import ids, { mapToApiOffense, mapToApiOffenseParam } from '../../src/util/offenses'
 
+
 describe('offenses utility', () => {
   it('default export should be an array', () => {
     expect(typeof ids.length).toEqual('number')

--- a/test/util/text.test.js
+++ b/test/util/text.test.js
@@ -2,6 +2,7 @@
 
 import { slugify } from '../../src/util/text'
 
+
 describe('text utility', () => {
   describe('slugify()', () => {
     it('should lowercase and replace spaces with hyphens', () => {

--- a/test/util/ucr.test.js
+++ b/test/util/ucr.test.js
@@ -7,6 +7,7 @@ import dataSourcesReportedByState, {
 } from '../../src/util/ucr'
 import { nationalKey } from '../../src/util/usa'
 
+
 describe('ucr utility', () => {
   it('should return a value for california', () => {
     const place = 'california'

--- a/test/util/url.test.js
+++ b/test/util/url.test.js
@@ -2,6 +2,7 @@
 
 import createUrl from '../../src/util/url'
 
+
 describe('url utility', () => {
   it('should properly form a url with an alphabetized query string', () => {
     const actual = createUrl('fake-url.com', { param: 'fake-param', another: 'more-fake' })

--- a/test/util/usa.test.js
+++ b/test/util/usa.test.js
@@ -2,6 +2,7 @@
 
 import lookup, { data as states } from '../../src/util/usa'
 
+
 describe('usa utility', () => {
   describe('with an abbreviation', () => {
     it('should return the proper state', () => {


### PR DESCRIPTION
@jeremiak -- i want to propose a pattern/standard for our file imports:

* 2 groupings: externals, relative
* within each, we alphabetize according to the `module` name (as opposed to the `function(s)` names. i think this has a few benefits: 1) it keeps related things together (for example, `d3-array`, `d3-scale`, etc., regardless of what the specific functions we import from those libraries are) 2) it means that if we change the name of a function that we import (or if we update which functions we import), we don't have to move the line that it's on.
* for relative imports, we group and alphabetize according to folder depth (i.e., first within same folder, then within `../foo`, then `../foo2`, then `../../bar`...)
* 2 lines after last import to better separate from main code

let me know what you think! if you like this, i'll update the remaining files :)