### PR TITLE
Fetch national participation data

### DIFF
--- a/src/actions/composite.js
+++ b/src/actions/composite.js
@@ -5,10 +5,13 @@ import { fetchSummaries } from '../actions/summary'
 import { fetchUcrParticipation } from '../actions/ucr'
 import history, { createNewLocation } from '../util/history'
 import { shouldFetchUcr, shouldFetchSummaries, shouldFetchNibrs } from '../util/ucr'
+import { nationalKey } from '../util/usa'
 
 const fetchData = () => (dispatch, getState) => {
-  const { filters } = getState()
+  const { filters, ucr } = getState()
+  const fetchNational = !ucr.data[nationalKey] && filters.place !== nationalKey
 
+  if (fetchNational) dispatch(fetchUcrParticipation(nationalKey))
   if (shouldFetchUcr(filters)) dispatch(fetchUcrParticipation(filters.place))
   if (shouldFetchSummaries(filters)) dispatch(fetchSummaries(filters))
   if (shouldFetchNibrs(filters)) dispatch(fetchNibrs(filters))


### PR DESCRIPTION
Now that we fetch the national participation data from the API, we cannot assume it will just be there when we need to draw trend lines. Right now this is causing the explorer interface to crash.

Because `shouldFetchUcr()` will return true for the `nationalKey` when it is the place and we don't want to fire off two requests for the same data, `fetchNational` will be false when the place is national.