### PR TITLE
Show missing term error in <Glossary />

### DIFF
--- a/src/components/Glossary.js
+++ b/src/components/Glossary.js
@@ -62,6 +62,8 @@ class Glossary extends React.Component {
   }
 
   render() {
+    const { error } = this.state
+
     return (
       <div>
         <div
@@ -86,8 +88,8 @@ class Glossary extends React.Component {
             type='search'
             placeholder='e.g. Committee'
           />
-          {this.state.error && (
-            <p className='fs-14 italic mt-tiny red'>{this.state.error}</p>
+          {error && (
+            <p className='my1 p1 fs-14 bold bg-red-bright white'>{error}</p>
           )}
           <div className='glossary__content' id='glossary-result'>
             <ul className='js-glossary-list' />

--- a/src/components/Glossary.js
+++ b/src/components/Glossary.js
@@ -13,6 +13,8 @@ class Glossary extends React.Component {
     this.applyProps = ::this.applyProps
     this.showTerm = ::this.showTerm
     this.toggleGlossary = ::this.toggleGlossary
+
+    this.state = { error: null }
   }
 
   componentDidMount() {
@@ -24,7 +26,10 @@ class Glossary extends React.Component {
     this.applyProps(nextProps)
   }
 
-  shouldComponentUpdate() { return false }
+  shouldComponentUpdate(nextProps, nextState) {
+    if (nextState.error) return true
+    return false
+  }
 
   setOpen(isOpen) {
     if (isOpen) this.glossaryEl.show()
@@ -32,7 +37,16 @@ class Glossary extends React.Component {
   }
 
   showTerm(term) {
-    if (term) this.glossaryEl.findTerm(term)
+    if (!term) return
+
+    try {
+      this.glossaryEl.findTerm(term.toLowerCase())
+      this.setState({ error: null })
+    } catch (e) {
+      if (e.message === 'Cannot read property \'elm\' of undefined') {
+        this.setState({ error: `Cannot find "${term}".` })
+      }
+    }
   }
 
   applyProps(props) {
@@ -72,6 +86,9 @@ class Glossary extends React.Component {
             type='search'
             placeholder='e.g. Committee'
           />
+          {this.state.error && (
+            <p className='fs-14 italic mt-tiny red'>{this.state.error}</p>
+          )}
           <div className='glossary__content' id='glossary-result'>
             <ul className='js-glossary-list' />
           </div>


### PR DESCRIPTION
Ensuring that the term is always lower cased fixed part of #599

Instead of crashing the application, show the user an error that informs them that their term cannot be found.
![screen shot 2017-03-17 at 12 49 46 am](https://cloud.githubusercontent.com/assets/780941/24029345/c3f4209c-0aab-11e7-9ee0-4c40df3008f9.png)
