### PR TITLE
Show percents by default in <NibrsTable />

### DIFF
--- a/src/components/NibrsTable.js
+++ b/src/components/NibrsTable.js
@@ -10,7 +10,7 @@ const formatSI = n => (Number(n) > 10 ? format('.2s')(n) : formatNumber(n))
 class NibrsTable extends React.Component {
   constructor(props) {
     super(props)
-    this.state = { showCounts: true }
+    this.state = { showCounts: false }
     this.showCounts = ::this.showCounts
     this.showPercents = ::this.showPercents
   }


### PR DESCRIPTION
@amberwreed Defaulting to percents still has a sentence with the total counts that don't add up.

Default to counts:
<img width="424" alt="screen shot 2017-03-23 at 6 08 03 pm" src="https://cloud.githubusercontent.com/assets/780941/24272468/e288c236-0ff3-11e7-901c-09c93c61caf8.png">

Default to percents:
<img width="431" alt="screen shot 2017-03-23 at 6 07 43 pm" src="https://cloud.githubusercontent.com/assets/780941/24272467/e2837de4-0ff3-11e7-841d-d70102a0a82e.png">

Refs #631 
