### PR TITLE
Make NIBRS text a <Term />

### DIFF
--- a/src/components/NibrsContainer.js
+++ b/src/components/NibrsContainer.js
@@ -76,7 +76,7 @@ const NibrsContainer = ({
         </h2>
         {(nibrsFirstYear !== since) && (
           <p className='my-tiny'>
-            {startCase(place)} started reporting incident-based (NIBRS) data
+            {startCase(place)} started reporting {nibrs} data
             to the FBI in {nibrsFirstYear}.
           </p>
         )}


### PR DESCRIPTION
Should address this [point from Nicole](https://github.com/18F/crime-data-explorer/issues/599#issuecomment-287437840) about backdated text including a glossary term link.