### PR TITLE
Update node LTS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "private": true,
   "engines": {
-    "node": "6.9.x"
+    "node": "6.10.x"
   },
   "scripts": {
     "start": "node build/server.js",


### PR DESCRIPTION
The Cloud Foundry buildpack got updated and node `v6.9.x` was removed in favor of `v.6.10.x` on the LTS branch.

Update the `package.json` so deploys to cloud.gov do not fail