### PR TITLE
Document release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Make sure to set the `API_KEY` environment variable with your API key for the [C
 
 Use `npm run watch` to start the continuous `webpack` processes and a webserver.
 
-## Running tests
+### Running tests
 
 You can lint the code with `npm run lint` and run tests with `npm run test`.
 
@@ -36,6 +36,34 @@ Tagged releases are deployed to https://crime-data-explorer-demo.fr.cloud.gov.
 A third, and less formal, environment is available at https://crime-data-explorer-staging.fr.cloud.gov. This is for ad-hoc usage and testing.
 
 Use `cf push -f manifest/staging.yml` to deploy. Remember that `cf` pushes from your local file structure and won't build the app on its own, so make sure you run `npm run build` before pushing.
+
+## Release process
+
+This app follows [semver](http://semver.org/) and [tags releases](https://github.com/18F/crime-data-explorer/releases) with the version number. You can see all notable changes in [CHANGELOG.md](changelog.md).
+
+### Manual testing
+
+1. Load homepage
+2. Select "Explorer" from navigation
+3. Ensure that a trend chart renders to show "Violent Crime rate in United States"
+4. Select "Alabama" as the location in the left hand side menu
+5. Select "Robbery" as the crime in the left hand side menu
+6. Ensure that the URL is now `/explorer/alabama/robbery`
+7. Ensure that a trend chart renders to show "Robbery rate in Alabama, 2004–2014"
+8. Scroll down and ensure donut charts, histograms, and tables render to show Robbery incident details in Alabama, 2004–2014"
+9. Scroll down and ensure there is a section called "About the data"
+10. Select "Downloads & Documentation" from the navigation at the top of the page or the footer at the bottom
+11. Select "Alabama" as the "Location" and "2000" as the "Year". Click download and ensure that a `.zip` file is downloaded
+12. Click the "Download data" link for "Hate crime" under "Bulk downloads" and ensure a file called `hate_crime.csv` is downloaded
+
+### Tagging a release
+
+1. Compile the notable changes into the [CHANGELOG.md](changelog.md). You can use the `/compare/:lastVersion...master` endpoint on Github. For example, this [`/compare` link was used to determine the changes in `v1.1.0`](https://github.com/18F/crime-data-explorer/compare/v1.0.0...33edf933009664a74e2601aa369f4bb6a67394c5)
+2. Determine if the version should be increased by a major, minor, or patch version
+3. Adjust the version number in `package.json` accordingly
+4. Submit a pull request without tagging the commit
+5. Once the pull request is merged, tag the merge commit as `vX.Y.Z` where `X`, `Y`, and `Z` reflect the same version number as the now merged change for `package.json`
+6. Push the tag to Github with `git push origin vX.Y.Z`
 
 ## Browser support
 

--- a/README.md
+++ b/README.md
@@ -39,18 +39,20 @@ Use `cf push -f manifest/staging.yml` to deploy. Remember that `cf` pushes from 
 
 ## Release process
 
-This app follows [semver](http://semver.org/) and [tags releases](https://github.com/18F/crime-data-explorer/releases) with the version number. You can see all notable changes in [CHANGELOG.md](changelog.md).
+This app follows [semver](http://semver.org/) and has [tagged releases](https://github.com/18F/crime-data-explorer/releases) by version number. You can see all notable changes in [CHANGELOG.md](https://github.com/18F/crime-data-explorer/blob/master/CHANGELOG.md).
 
-### Manual testing
+### Manual verification
 
-1. Load homepage
+Though unit test coverage is decent (check with `npm run coverage`, as of [`cdb2340`](https://github.com/18F/crime-data-explorer/commit/cdb2340830b0325dc9a05ba443a1a84c2e835430) it was about 77% of all statements), we run through a few basic user scenarios before tagging a release to check the application.
+
+1. Load homepage from `master` branch. Can be local or https://crime-data-explorer.fr.cloud.gov
 2. Select "Explorer" from navigation
 3. Ensure that a trend chart renders to show "Violent Crime rate in United States"
 4. Select "Alabama" as the location in the left hand side menu
 5. Select "Robbery" as the crime in the left hand side menu
 6. Ensure that the URL is now `/explorer/alabama/robbery`
 7. Ensure that a trend chart renders to show "Robbery rate in Alabama, 2004–2014"
-8. Scroll down and ensure donut charts, histograms, and tables render to show Robbery incident details in Alabama, 2004–2014"
+8. Scroll down and ensure donut charts, histograms, and tables render to show "Robbery incident details in Alabama, 2004–2014"
 9. Scroll down and ensure there is a section called "About the data"
 10. Select "Downloads & Documentation" from the navigation at the top of the page or the footer at the bottom
 11. Select "Alabama" as the "Location" and "2000" as the "Year". Click download and ensure that a `.zip` file is downloaded
@@ -58,7 +60,7 @@ This app follows [semver](http://semver.org/) and [tags releases](https://github
 
 ### Tagging a release
 
-1. Compile the notable changes into the [CHANGELOG.md](changelog.md). You can use the `/compare/:lastVersion...master` endpoint on Github. For example, this [`/compare` link was used to determine the changes in `v1.1.0`](https://github.com/18F/crime-data-explorer/compare/v1.0.0...33edf933009664a74e2601aa369f4bb6a67394c5)
+1. Compile the notable changes into the [CHANGELOG.md](https://github.com/18F/crime-data-explorer/blob/master/CHANGELOG.md). You can use the `/compare/:lastVersion...master` endpoint on Github. For example, this [`/compare` link was used to determine the changes in `v1.1.0`](https://github.com/18F/crime-data-explorer/compare/v1.0.0...33edf933009664a74e2601aa369f4bb6a67394c5)
 2. Determine if the version should be increased by a major, minor, or patch version
 3. Adjust the version number in `package.json` accordingly
 4. Submit a pull request without tagging the commit

--- a/manifests/demo.yml
+++ b/manifests/demo.yml
@@ -8,3 +8,4 @@ services:
 - crime-data-api-creds
 env:
   NODE_ENV: 'production'
+  CDE_API: 'https://crime-data-api-demo.fr.cloud.gov'

--- a/manifests/master.yml
+++ b/manifests/master.yml
@@ -8,3 +8,4 @@ services:
 - crime-data-api-creds
 env:
   NODE_ENV: 'production'
+  CDE_API: 'https://crime-data-api.fr.cloud.gov'

--- a/manifests/staging.yml
+++ b/manifests/staging.yml
@@ -8,3 +8,4 @@ services:
 - crime-data-api-creds
 env:
   NODE_ENV: 'production'
+  CDE_API: 'https://crime-data-api.fr.cloud.gov'

--- a/src/server.js
+++ b/src/server.js
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV === 'production') require('newrelic')
 const env = cfenv.getAppEnv()
 const credService = env.getService('crime-data-api-creds') || { credentials: {} }
 const apiKey = credService.credentials.API_KEY || process.env.API_KEY || false
-const API = 'https://crime-data-api.fr.cloud.gov'
+const API = process.env.CDE_API
 
 const app = express()
 


### PR DESCRIPTION
Document release process to facilitate sharing with the FBI and set the app to use a `CDE_API` environment variable for the API host URL instead of having it in the code base. This makes it easier to switch to using the more stable `-demo` API when we deploy a tagged release.