### PR TITLE
Gzip bundle.js in build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-polyfill": "^6.20.0",
     "basscss-sass": "^4.0.0",
     "cfenv": "^1.0.3",
+    "connect-gzip-static": "^2.0.1",
     "d3-array": "^1.0.2",
     "d3-collection": "^1.0.2",
     "d3-format": "^1.0.2",
@@ -66,6 +67,7 @@
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
+    "compression-webpack-plugin": "^0.3.2",
     "css-loader": "^0.26.1",
     "enzyme": "^2.6.0",
     "eslint": "^3.11.1",
@@ -91,6 +93,10 @@
     "yaml-loader": "^0.4.0"
   },
   "babel": {
-    "presets": ["es2015", "stage-0", "react"]
+    "presets": [
+      "es2015",
+      "stage-0",
+      "react"
+    ]
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,7 @@ import 'babel-polyfill'
 import http from 'axios'
 import cfenv from 'cfenv'
 import express from 'express'
+import gzipStatic from 'connect-gzip-static'
 import path from 'path'
 import React from 'react'
 import { renderToString } from 'react-dom/server'
@@ -27,8 +28,8 @@ const API = 'https://crime-data-api.fr.cloud.gov'
 
 const app = express()
 
-app.use(express.static(__dirname))
-app.use(express.static(path.join(__dirname, '..', 'public')))
+app.use(gzipStatic(__dirname))
+app.use(gzipStatic(path.join(__dirname, '..', 'public')))
 
 app.get('/status', (req, res) => res.send('OK'))
 

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -3,7 +3,9 @@
 var path = require('path')
 
 var autoprefixer = require('autoprefixer')
+var CompressionPlugin = require('compression-webpack-plugin')
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
+
 var webpack = require('webpack')
 
 var env = process.env.NODE_ENV || 'development'
@@ -43,6 +45,13 @@ var config = {
     autoprefixer({ browsers: ['last 2 versions', '> 5%'] })
   ],
   plugins: [
+    new CompressionPlugin({
+      asset: '[path].gz[query]',
+      algorithm: 'gzip',
+      test: /\.js$/,
+      threshold: 10240,
+      minRatio: 0.8
+    }),
     new ExtractTextPlugin('app.css'),
     new webpack.DefinePlugin({
       'process.env': {


### PR DESCRIPTION
To reduce the size of the file we transfer over the network, we want to gzip, at least, the `bundle.js` file.

Using some middleware that checks for a compressed file (by adding `.gz` to the requested file name) and serves it if available. Otherwise, serves the static files just like before.

size of `bundle.js`:

|  | development | production
--|--|--
without gzipping | 2.3MB | 799KB
with gzipping | 522KB | 249KB