### PR TITLE
Add app version to /status and to footer

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import Link from './Link'
-
+import packageJson from '../../package.json'
 
 const links = [
   {
@@ -44,6 +44,15 @@ const Footer = () => (
         <Link to='/' className='fs-24 md-fs-32 serif line-height-1 white'>
           Crime Data Explorer
         </Link>
+        <span className='block fs-10'>
+          v{packageJson.version} -{' '}
+          <a
+            className='white'
+            href='https://github.com/18F/crime-data-explorer/blob/master/CHANGELOG.md'
+          >
+            Changelog
+          </a>
+        </span>
       </div>
       <div className='clearfix mxn2'>
         <div className='md-col md-col-5 px2 mb3 md-m0'>

--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,7 @@ import { renderToString } from 'react-dom/server'
 import { Provider } from 'react-redux'
 import { match, RouterContext } from 'react-router'
 
+import packageJson from '../package.json'
 import renderHtml from './html'
 import routes from './routes'
 import configureStore from './store'
@@ -30,7 +31,7 @@ const app = express()
 app.use(express.static(__dirname))
 app.use(express.static(path.join(__dirname, '..', 'public')))
 
-app.get('/status', (req, res) => res.send('OK'))
+app.get('/status', (req, res) => res.send(`OK v${packageJson.version}`))
 
 app.get('/api/*', (req, res) => {
   const route = `${API}/${req.params['0']}`.replace(/\/$/g, '')


### PR DESCRIPTION
Quick proposal for #594, adding version number to `/status` response and to the `<Footer />` component

<img width="1245" alt="screen shot 2017-04-05 at 4 20 33 pm" src="https://cloud.githubusercontent.com/assets/780941/24725211/f2d6a07c-1a1b-11e7-8dbc-526b1e6f80f5.png">
